### PR TITLE
Draft: Integration of policy engine into the new controlplane

### DIFF
--- a/cmd/gwctl/subcommand/policy.go
+++ b/cmd/gwctl/subcommand/policy.go
@@ -62,7 +62,7 @@ func (o *policyCreateOptions) run() error {
 	}
 	switch o.pType {
 	case policyengine.LbType:
-		return g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.PolicyLoadBalancer(o.policy), o.gwDest, client.Add)
+		return g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.LBScheme(o.policy), o.gwDest, client.Add)
 	case policyengine.AccessType:
 		policy, err := policyFromFile(o.policyFile)
 		if err != nil {
@@ -136,7 +136,7 @@ func (o *policyDeleteOptions) run() error {
 	}
 	switch o.pType {
 	case policyengine.LbType:
-		err = g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.PolicyLoadBalancer(o.policy), o.gwDest, client.Del)
+		err = g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.LBScheme(o.policy), o.gwDest, client.Del)
 	case policyengine.AccessType:
 		policy, err := policyFromFile(o.policyFile)
 		if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,7 +82,7 @@ func (c *Client) SendAccessPolicy(policy api.Policy, command int) error {
 }
 
 // SendLBPolicy sends an LB request to the GW.
-func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine.PolicyLoadBalancer, gwDest string, command int) error {
+func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, scheme policyengine.LBScheme, gwDest string, command int) error {
 	path := policyengine.PolicyRoute + policyengine.LbRoute
 	switch command {
 	case Add:
@@ -92,7 +92,7 @@ func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine
 	default:
 		return fmt.Errorf("unknown command")
 	}
-	jsonReq, err := json.Marshal(policyengine.LoadBalancerRule{ServiceSrc: serviceSrc, ServiceDst: serviceDst, Policy: policy, DefaultMbg: gwDest})
+	jsonReq, err := json.Marshal(policyengine.LBPolicy{ServiceSrc: serviceSrc, ServiceDst: serviceDst, Scheme: scheme, DefaultMbg: gwDest})
 	if err != nil {
 		return err
 	}
@@ -101,16 +101,16 @@ func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine
 }
 
 // GetLBPolicies sends an LB get request to the GW.
-func (c *Client) GetLBPolicies() (map[string]map[string]policyengine.PolicyLoadBalancer, error) {
-	var policies map[string]map[string]policyengine.PolicyLoadBalancer
+func (c *Client) GetLBPolicies() (map[string]map[string]policyengine.LBScheme, error) {
+	var policies map[string]map[string]policyengine.LBScheme
 	path := policyengine.PolicyRoute + policyengine.LbRoute
 	resp, err := c.client.Get(path)
 	if err != nil {
-		return make(map[string]map[string]policyengine.PolicyLoadBalancer), err
+		return make(map[string]map[string]policyengine.LBScheme), err
 	}
 
 	if err := json.Unmarshal(resp.Body, &policies); err != nil {
-		return make(map[string]map[string]policyengine.PolicyLoadBalancer), err
+		return make(map[string]map[string]policyengine.LBScheme), err
 	}
 	return policies, nil
 }

--- a/pkg/controlplane/store/accesspolicies.go
+++ b/pkg/controlplane/store/accesspolicies.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/clusterlink-org/clusterlink/pkg/store"
+)
+
+// AccessPolicies is a cached persistent store of Access Policies.
+type AccessPolicies struct {
+	lock  sync.RWMutex
+	cache map[string]*AccessPolicy
+	store store.ObjectStore
+
+	logger *logrus.Entry
+}
+
+// Create an AccessPolicy.
+func (s *AccessPolicies) Create(policy *AccessPolicy) error {
+	s.logger.Infof("Creating: '%s'.", policy.Name)
+
+	if policy.Version > accessPolicyStructVersion {
+		return fmt.Errorf("incompatible access policy version %d, expected: %d",
+			policy.Version, accessPolicyStructVersion)
+	}
+
+	// persist to store
+	if err := s.store.Create(policy.Name, policy); err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store in cache
+	s.cache[policy.Name] = policy
+	return nil
+}
+
+// Update an access policy.
+func (s *AccessPolicies) Update(name string, mutator func(*AccessPolicy) *AccessPolicy) error {
+	s.logger.Infof("Updating: '%s'.", name)
+
+	// persist to store
+	var policy *AccessPolicy
+	err := s.store.Update(name, func(a any) any {
+		policy = mutator(a.(*AccessPolicy))
+		return policy
+	})
+	if err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store in cache
+	s.cache[name] = policy
+	return nil
+}
+
+// Get an access policy.
+func (s *AccessPolicies) Get(name string) *AccessPolicy {
+	s.logger.Debugf("Getting '%s'.", name)
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.cache[name]
+}
+
+// Delete an access policy.
+func (s *AccessPolicies) Delete(name string) (*AccessPolicy, error) {
+	s.logger.Infof("Deleting: '%s'.", name)
+
+	// delete from store
+	if err := s.store.Delete(name); err != nil {
+		return nil, err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// delete from cache
+	val := s.cache[name]
+	delete(s.cache, name)
+	return val, nil
+}
+
+// GetAll returns all access policies in the cache.
+func (s *AccessPolicies) GetAll() []*AccessPolicy {
+	s.logger.Debug("Getting all access policies.")
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	policies := make([]*AccessPolicy, 0, len(s.cache))
+	for _, policy := range s.cache {
+		policies = append(policies, policy)
+	}
+
+	return policies
+}
+
+// Len returns the number of cached access policies.
+func (s *AccessPolicies) Len() int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return len(s.cache)
+}
+
+// init loads the cache with items from the backing store.
+func (s *AccessPolicies) init() error {
+	s.logger.Info("Initializing.")
+
+	// get all policies from backing store
+	policies, err := s.store.GetAll()
+	if err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store all policies to the cache
+	for _, object := range policies {
+		policy := object.(*AccessPolicy)
+		s.cache[policy.Name] = policy
+	}
+
+	return nil
+}
+
+// NewAccessPolicies returns a new cached store of access policies.
+func NewAccessPolicies(manager store.Manager) (*AccessPolicies, error) {
+	logger := logrus.WithField("component", "controlplane.store.accesspolicies")
+
+	policies := &AccessPolicies{
+		cache:  make(map[string]*AccessPolicy),
+		store:  manager.GetObjectStore(accessPolicyStoreName, AccessPolicy{}),
+		logger: logger,
+	}
+
+	if err := policies.init(); err != nil {
+		return nil, err
+	}
+
+	return policies, nil
+}

--- a/pkg/controlplane/store/types.go
+++ b/pkg/controlplane/store/types.go
@@ -5,15 +5,17 @@ import (
 )
 
 const (
-	peerStoreName    = "peer"
-	exportStoreName  = "export"
-	importStoreName  = "import"
-	bindingStoreName = "binding"
+	peerStoreName         = "peer"
+	exportStoreName       = "export"
+	importStoreName       = "import"
+	bindingStoreName      = "binding"
+	accessPolicyStoreName = "accessPolicy"
 
-	bindingStructVersion = 1
-	exportStructVersion  = 1
-	importStructVersion  = 1
-	peerStructVersion    = 1
+	bindingStructVersion      = 1
+	exportStructVersion       = 1
+	importStructVersion       = 1
+	peerStructVersion         = 1
+	accessPolicyStructVersion = 1
 )
 
 // Peer represents a remote peer.
@@ -99,5 +101,25 @@ func NewBinding(binding *api.Binding) *Binding {
 	return &Binding{
 		BindingSpec: binding.Spec,
 		Version:     bindingStructVersion,
+	}
+}
+
+// AccessPolicy to allow/deny specific connections
+type AccessPolicy struct {
+	api.Policy
+	// Version of the struct when object was created.
+	Version uint32
+}
+
+// Keys return the keys identifying the policy.
+func (ap *AccessPolicy) Keys() []string {
+	return []string{ap.Name}
+}
+
+// NewAccessPolicy creates a new access policy
+func NewAccessPolicy(policy *api.Policy) *AccessPolicy {
+	return &AccessPolicy{
+		Policy:  *policy,
+		Version: accessPolicyStructVersion,
 	}
 }


### PR DESCRIPTION
Includes:
* API calls to CRUD access policies
* Calling policy engine to authorize outgoing/incoming connections
* Policy engine sets remote peer for outgoing connections
* Calling policy engine to authorize adding bindings and exports
* Informing policy engine of added/removed peers and removed bindings and exports
* Persistent storage of access policies

Does not include:
* Handling load-balancing policies
