### PR TITLE
Makefile: Fix docker-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build:
 	$(GO) build -o ./bin/cl-dataplane ./cmd/cl-dataplane
 
 
-docker-build: 
+docker-build: build
 	docker build --progress=plain --rm --tag mbg .
 	docker build --progress=plain --rm --tag cl-controlplane -f ./cmd/cl-controlplane/Dockerfile .
 	docker build --progress=plain --rm --tag cl-dataplane -f ./cmd/cl-dataplane/Dockerfile .


### PR DESCRIPTION
This PR fixes the docker-build target to run the build target before proceeding with the docker build.
This is required for building the gwctl, cl-controlplane, and cl-dataplane images.