### PR TITLE
cmd: Introduce cl-adm

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -23,5 +23,9 @@ jobs:
       uses: actions/checkout@v3
     - name: Run build
       run: make build
+    - name: Build docker images
+      run: make docker-build
+    - name: Run e2e connectivity test on a kind cluster
+      run: ./tests/k8s.sh
     - name: Run end-to-end tests
       run: make tests-e2e

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ build:
 	$(GO) build -o ./bin/dataplane ./cmd/dataplane/main.go
 	$(GO) build -o ./bin/cl-controlplane ./cmd/cl-controlplane
 	$(GO) build -o ./bin/cl-dataplane ./cmd/cl-dataplane
+	$(GO) build -o ./bin/cl-adm ./cmd/cl-adm
 
 
 docker-build: build

--- a/cmd/cl-adm/cl-adm.go
+++ b/cmd/cl-adm/cl-adm.go
@@ -1,0 +1,18 @@
+// The cl-adm binary is used for preparing a clusterlink deployment.
+// The deployment includes certificate files for establishing secure TLS connections
+// with other cluster components, and configuration for spawning up the various clusterlink
+// components in different environments.
+package main
+
+import (
+	"os"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/cmd"
+)
+
+func main() {
+	command := cmd.NewCLADMCommand()
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/cl-adm/cmd/cmd.go
+++ b/cmd/cl-adm/cmd/cmd.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/cmd/create"
+)
+
+// NewCLADMCommand returns a cobra.Command to run the cl-adm command.
+func NewCLADMCommand() *cobra.Command {
+	cmds := &cobra.Command{
+		Use:          "cl-adm",
+		Short:        "cl-adm: bootstrap a clink fabric",
+		Long:         `cl-adm: bootstrap a clink fabric`,
+		SilenceUsage: true,
+	}
+
+	cmds.AddCommand(create.NewCmdCreate())
+
+	return cmds
+}

--- a/cmd/cl-adm/cmd/create/create.go
+++ b/cmd/cl-adm/cmd/create/create.go
@@ -1,0 +1,17 @@
+package create
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdCreate returns a cobra.Command to run the create command.
+func NewCmdCreate() *cobra.Command {
+	cmds := &cobra.Command{
+		Use: "create",
+	}
+
+	cmds.AddCommand(NewCmdCreateFabric())
+	cmds.AddCommand(NewCmdCreatePeer())
+
+	return cmds
+}

--- a/cmd/cl-adm/cmd/create/create_fabric.go
+++ b/cmd/cl-adm/cmd/create/create_fabric.go
@@ -1,0 +1,26 @@
+package create
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/util"
+)
+
+// NewCmdCreateFabric returns a cobra.Command to run the 'create fabric' subcommand.
+func NewCmdCreateFabric() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fabric",
+		Short: "Create a fabric",
+		Long:  `Create a fabric`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return util.CreateCertificate(&util.CertificateConfig{
+				Name:              "root",
+				IsCA:              true,
+				CertOutPath:       config.CertificateFileName,
+				PrivateKeyOutPath: config.PrivateKeyFileName,
+			})
+		},
+	}
+}

--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -1,0 +1,193 @@
+package create
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/templates"
+	"github.com/clusterlink-net/clusterlink/pkg/controlplane/api"
+	dpapi "github.com/clusterlink-net/clusterlink/pkg/dataplane/api"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/net/idna"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/util"
+)
+
+// PeerOptions contains everything necessary to create and run a 'create peer' subcommand.
+type PeerOptions struct {
+	// Name of the peer to create.
+	Name string
+	// Dataplanes is the number of dataplanes to create.
+	Dataplanes uint16
+}
+
+// AddFlags adds flags to fs and binds them to options.
+func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Name, "name", "", "Peer name.")
+	fs.Uint16Var(&o.Dataplanes, "dataplanes", 1, "Number of dataplanes.")
+}
+
+// RequiredFlags are the names of flags that must be explicitly specified.
+func (o *PeerOptions) RequiredFlags() []string {
+	return []string{"name"}
+}
+
+func (o *PeerOptions) createControlplane() error {
+	if err := os.Mkdir(config.ControlplaneDirectory(o.Name), 0755); err != nil {
+		return err
+	}
+
+	// create certificate
+	peerDirectory := config.PeerDirectory(o.Name)
+	controlplaneDirectory := config.ControlplaneDirectory(o.Name)
+	return util.CreateCertificate(&util.CertificateConfig{
+		Name:              "cl-controlplane",
+		IsServer:          true,
+		IsClient:          true,
+		DNSNames:          []string{o.Name, api.GRPCServerName(o.Name)},
+		CAPath:            filepath.Join(peerDirectory, config.CertificateFileName),
+		CAKeyPath:         filepath.Join(peerDirectory, config.PrivateKeyFileName),
+		CertOutPath:       filepath.Join(controlplaneDirectory, config.CertificateFileName),
+		PrivateKeyOutPath: filepath.Join(controlplaneDirectory, config.PrivateKeyFileName),
+	})
+}
+
+func (o *PeerOptions) createDataplane() error {
+	if err := os.Mkdir(config.DataplaneDirectory(o.Name), 0755); err != nil {
+		return err
+	}
+
+	// create certificate
+	peerDirectory := config.PeerDirectory(o.Name)
+	dataplaneDirectory := config.DataplaneDirectory(o.Name)
+	return util.CreateCertificate(&util.CertificateConfig{
+		Name:              "dataplane",
+		IsServer:          true,
+		IsClient:          true,
+		DNSNames:          []string{dpapi.DataplaneServerName(o.Name)},
+		CAPath:            filepath.Join(peerDirectory, config.CertificateFileName),
+		CAKeyPath:         filepath.Join(peerDirectory, config.PrivateKeyFileName),
+		CertOutPath:       filepath.Join(dataplaneDirectory, config.CertificateFileName),
+		PrivateKeyOutPath: filepath.Join(dataplaneDirectory, config.PrivateKeyFileName),
+	})
+}
+
+func (o *PeerOptions) createGWCTL() error {
+	if err := os.Mkdir(config.GWCTLDirectory(o.Name), 0755); err != nil {
+		return err
+	}
+
+	// create certificate
+	peerDirectory := config.PeerDirectory(o.Name)
+	gwctlDirectory := config.GWCTLDirectory(o.Name)
+	return util.CreateCertificate(&util.CertificateConfig{
+		Name:              "gwctl",
+		IsClient:          true,
+		CAPath:            filepath.Join(peerDirectory, config.CertificateFileName),
+		CAKeyPath:         filepath.Join(peerDirectory, config.PrivateKeyFileName),
+		CertOutPath:       filepath.Join(gwctlDirectory, config.CertificateFileName),
+		PrivateKeyOutPath: filepath.Join(gwctlDirectory, config.PrivateKeyFileName),
+	})
+}
+
+// Run the 'create peer' subcommand.
+func (o *PeerOptions) Run() error {
+	if _, err := idna.Lookup.ToASCII(o.Name); err != nil {
+		return fmt.Errorf("peer name is not a valid DNS name: %v", err)
+	}
+
+	if err := verifyNotExists(o.Name); err != nil {
+		return err
+	}
+
+	peerDirectory := config.PeerDirectory(o.Name)
+	if err := os.Mkdir(peerDirectory, 0755); err != nil {
+		return err
+	}
+
+	err := util.CreateCertificate(&util.CertificateConfig{
+		Name:              o.Name,
+		IsCA:              true,
+		DNSNames:          []string{o.Name},
+		CAPath:            config.CertificateFileName,
+		CAKeyPath:         config.PrivateKeyFileName,
+		CertOutPath:       filepath.Join(peerDirectory, config.CertificateFileName),
+		PrivateKeyOutPath: filepath.Join(peerDirectory, config.PrivateKeyFileName),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := o.createControlplane(); err != nil {
+		return err
+	}
+
+	if err := o.createDataplane(); err != nil {
+		return err
+	}
+
+	if err := o.createGWCTL(); err != nil {
+		return err
+	}
+
+	// deployment configuration
+	args, err := templates.Config{
+		Peer:       o.Name,
+		Dataplanes: o.Dataplanes,
+	}.TemplateArgs()
+	if err != nil {
+		return err
+	}
+
+	// create docker run script
+	if err := templates.CreateDockerRunScripts(args, peerDirectory); err != nil {
+		return err
+	}
+
+	// create k8s deployment yaml
+	return templates.CreateK8SConfig(args, peerDirectory)
+}
+
+// NewCmdCreatePeer returns a cobra.Command to run the 'create peer' subcommand.
+func NewCmdCreatePeer() *cobra.Command {
+	opts := &PeerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "peer",
+		Short: "Create a peer",
+		Long:  `Create a peer`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	for _, flag := range opts.RequiredFlags() {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			fmt.Printf("Error marking required flag '%s': %v\n", flag, err)
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+// verifyNotExists verifies a given path does not exist.
+func verifyNotExists(path string) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		return fmt.Errorf("path %s exists", path)
+	}
+
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cl-adm/config/config.go
+++ b/cmd/cl-adm/config/config.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"path/filepath"
+)
+
+const (
+	// PrivateKeyFileName is the filename used by private key files.
+	PrivateKeyFileName = "key.pem"
+	// CertificateFileName is the filename used by certificate files.
+	CertificateFileName = "cert.pem"
+	// DockerRunFile is the filename of the docker-run script.
+	DockerRunFile = "docker-run.sh"
+	// GWCTLInitFile is the filename of the gwctl-init script.
+	GWCTLInitFile = "gwctl-init.sh"
+	// K8SYamlFile is the filename of the kubernetes deployment yaml file.
+	K8SYamlFile = "k8s.yaml"
+	// PersistencyDirectoryName is the directory name containing container persisted files.
+	PersistencyDirectoryName = "persist"
+
+	// ControlplaneDirectoryName is the directory name containing controlplane server configuration.
+	ControlplaneDirectoryName = "controlplane"
+	// DataplaneDirectoryName is the directory name containing dataplane server configuration.
+	DataplaneDirectoryName = "dataplane"
+	// GWCTLDirectoryName is the directory name containing gwctl certificates.
+	GWCTLDirectoryName = "gwctl"
+)
+
+// FabricDirectory returns the base path of the fabric.
+func FabricDirectory() string {
+	return "."
+}
+
+// PeerDirectory returns the base path for a specific peer.
+func PeerDirectory(peer string) string {
+	return filepath.Join(FabricDirectory(), peer)
+}
+
+// ControlplaneDirectory returns the path for a controlplane server.
+func ControlplaneDirectory(peer string) string {
+	return filepath.Join(PeerDirectory(peer), ControlplaneDirectoryName)
+}
+
+// DataplaneDirectory returns the path for a dataplane server.
+func DataplaneDirectory(peer string) string {
+	return filepath.Join(PeerDirectory(peer), DataplaneDirectoryName)
+}
+
+// GWCTLDirectory returns the path for a gwctl instance.
+func GWCTLDirectory(peer string) string {
+	return filepath.Join(PeerDirectory(peer), GWCTLDirectoryName)
+}

--- a/cmd/cl-adm/templates/config.go
+++ b/cmd/cl-adm/templates/config.go
@@ -1,0 +1,104 @@
+package templates
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+	cpapp "github.com/clusterlink-net/clusterlink/cmd/cl-controlplane/app"
+	dpapp "github.com/clusterlink-net/clusterlink/cmd/cl-dataplane/app"
+	cpapi "github.com/clusterlink-net/clusterlink/pkg/controlplane/api"
+	dpapi "github.com/clusterlink-net/clusterlink/pkg/dataplane/api"
+)
+
+// Config holds a configuration to instantiate a template.
+type Config struct {
+	// Peer is the peer name.
+	Peer string
+
+	// Dataplanes is the number of dataplane servers to run.
+	Dataplanes uint16
+}
+
+// TemplateArgs returns arguments for instantiating a text/template
+func (c Config) TemplateArgs() (map[string]interface{}, error) {
+	fabricCA, err := os.ReadFile(filepath.Join(config.FabricDirectory(), config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	peerCA, err := os.ReadFile(filepath.Join(config.PeerDirectory(c.Peer), config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	controlplaneCert, err := os.ReadFile(filepath.Join(config.ControlplaneDirectory(c.Peer), config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	controlplaneKey, err := os.ReadFile(filepath.Join(config.ControlplaneDirectory(c.Peer), config.PrivateKeyFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	dataplaneCert, err := os.ReadFile(filepath.Join(config.DataplaneDirectory(c.Peer), config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	dataplaneKey, err := os.ReadFile(filepath.Join(config.DataplaneDirectory(c.Peer), config.PrivateKeyFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	gwctlCert, err := os.ReadFile(filepath.Join(config.GWCTLDirectory(c.Peer), config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	gwctlKey, err := os.ReadFile(filepath.Join(config.GWCTLDirectory(c.Peer), config.PrivateKeyFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]interface{}{
+		"peer":       c.Peer,
+		"dataplanes": c.Dataplanes,
+
+		"fabricCA":         base64.StdEncoding.EncodeToString(fabricCA),
+		"peerCA":           base64.StdEncoding.EncodeToString(peerCA),
+		"controlplaneCert": base64.StdEncoding.EncodeToString(controlplaneCert),
+		"controlplaneKey":  base64.StdEncoding.EncodeToString(controlplaneKey),
+		"dataplaneCert":    base64.StdEncoding.EncodeToString(dataplaneCert),
+		"dataplaneKey":     base64.StdEncoding.EncodeToString(dataplaneKey),
+		"gwctlCert":        base64.StdEncoding.EncodeToString(gwctlCert),
+		"gwctlKey":         base64.StdEncoding.EncodeToString(gwctlKey),
+
+		"fabricCAPath":         filepath.Join(config.FabricDirectory(), config.CertificateFileName),
+		"peerCAPath":           filepath.Join(config.PeerDirectory(c.Peer), config.CertificateFileName),
+		"controlplaneCertPath": filepath.Join(config.ControlplaneDirectory(c.Peer), config.CertificateFileName),
+		"controlplaneKeyPath":  filepath.Join(config.ControlplaneDirectory(c.Peer), config.PrivateKeyFileName),
+		"dataplaneCertPath":    filepath.Join(config.DataplaneDirectory(c.Peer), config.CertificateFileName),
+		"dataplaneKeyPath":     filepath.Join(config.DataplaneDirectory(c.Peer), config.PrivateKeyFileName),
+		"gwctlCertPath":        filepath.Join(config.GWCTLDirectory(c.Peer), config.CertificateFileName),
+		"gwctlKeyPath":         filepath.Join(config.GWCTLDirectory(c.Peer), config.PrivateKeyFileName),
+
+		"controlplanePersistencyDirectory": filepath.Join(config.ControlplaneDirectory(c.Peer), config.PersistencyDirectoryName),
+		"dataplanePersistencyDirectory":    filepath.Join(config.DataplaneDirectory(c.Peer), config.PersistencyDirectoryName),
+
+		"persistencyDirectoryMountPath": filepath.Dir(cpapp.StoreFile),
+
+		"controlplaneCAMountPath":   cpapp.CAFile,
+		"controlplaneCertMountPath": cpapp.CertificateFile,
+		"controlplaneKeyMountPath":  cpapp.KeyFile,
+
+		"dataplaneCAMountPath":   dpapp.CAFile,
+		"dataplaneCertMountPath": dpapp.CertificateFile,
+		"dataplaneKeyMountPath":  dpapp.KeyFile,
+
+		"controlplanePort": cpapi.ListenPort,
+		"dataplanePort":    dpapi.ListenPort,
+	}, nil
+}

--- a/cmd/cl-adm/templates/docker.go
+++ b/cmd/cl-adm/templates/docker.go
@@ -1,0 +1,69 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+)
+
+const (
+	dockerRunTemplate = `#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+FABRIC_DIR=$SCRIPT_DIR/..
+
+docker run -itd \
+--name {{.peer}}-controlplane \
+-v $FABRIC_DIR/{{.fabricCAPath}}:{{.controlplaneCAMountPath}} \
+-v $FABRIC_DIR/{{.controlplaneCertPath}}:{{.controlplaneCertMountPath}} \
+-v $FABRIC_DIR/{{.controlplaneKeyPath}}:{{.controlplaneKeyMountPath}} \
+-v $FABRIC_DIR/{{.controlplanePersistencyDirectory}}:{{.persistencyDirectoryMountPath}} \
+cl-controlplane \
+cl-controlplane \
+--log-level info \
+--log-file {{.persistencyDirectoryMountPath}}/log.log \
+
+docker run -itd \
+--name {{.peer}}-dataplane \
+-v $FABRIC_DIR/{{.fabricCAPath}}:{{.dataplaneCAMountPath}} \
+-v $FABRIC_DIR/{{.dataplaneCertPath}}:{{.dataplaneCertMountPath}} \
+-v $FABRIC_DIR/{{.dataplaneKeyPath}}:{{.dataplaneKeyMountPath}} \
+-v $FABRIC_DIR/{{.dataplanePersistencyDirectory}}:{{.persistencyDirectoryMountPath}} \
+cl-dataplane \
+cl-dataplane \
+--controlplane-host {{.peer}}-controlplane \
+--log-level info \
+--log-file {{.persistencyDirectoryMountPath}}/log.log
+
+docker run -itd \
+--name {{.peer}}-gwctl \
+-v $FABRIC_DIR/{{.peerCAPath}}:/root/ca.pem \
+-v $FABRIC_DIR/{{.gwctlCertPath}}:/root/cert.pem \
+-v $FABRIC_DIR/{{.gwctlKeyPath}}:/root/key.pem \
+gwctl \
+/bin/sh -c "gwctl init --id {{.peer}} \
+                       --gwIP {{.peer}}-dataplane \
+                       --gwPort 443 \
+                       --certca /root/ca.pem \
+                       --cert /root/cert.pem \
+                       --key /root/key.pem &&
+            gwctl config use-context --myid {{.peer}} &&
+            sleep infinity"`
+)
+
+// CreateDockerRunScripts creates docker run shell scripts for running the various clusterlink components.
+func CreateDockerRunScripts(args map[string]interface{}, outDir string) error {
+	var dockerRunScript bytes.Buffer
+	t := template.Must(template.New("").Parse(dockerRunTemplate))
+	if err := t.Execute(&dockerRunScript, args); err != nil {
+		return fmt.Errorf("cannot create docker run script off template: %v", err)
+	}
+
+	outPath := filepath.Join(outDir, config.DockerRunFile)
+	//#nosec G306 -- script needs to be runnable
+	return os.WriteFile(outPath, dockerRunScript.Bytes(), 0700)
+}

--- a/cmd/cl-adm/templates/k8s.go
+++ b/cmd/cl-adm/templates/k8s.go
@@ -1,0 +1,234 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+)
+
+const (
+	k8sTemplate = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cl-fabric
+data:
+  ca: {{.fabricCA}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cl-peer
+data:
+  ca: {{.peerCA}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cl-controlplane
+data:
+  cert: {{.controlplaneCert}}
+  key: {{.controlplaneKey}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cl-dataplane
+data:
+  cert: {{.dataplaneCert}}
+  key: {{.dataplaneKey}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gwctl
+data:
+  cert: {{.gwctlCert}}
+  key: {{.gwctlKey}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cl-controlplane
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cl-controlplane
+  labels:
+    app: cl-controlplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cl-controlplane
+  template:
+    metadata:
+      labels:
+        app: cl-controlplane
+    spec:
+      volumes:
+        - name: ca
+          secret:
+            secretName: cl-fabric
+        - name: tls
+          secret:
+            secretName: cl-controlplane
+        - name: cl-controlplane
+          persistentVolumeClaim:
+            claimName: cl-controlplane
+      containers:
+        - name: cl-controlplane
+          image: cl-controlplane
+          imagePullPolicy: IfNotPresent
+          args: ["--log-level", "info"]
+          ports:
+            - containerPort: {{.controlplanePort}}
+          volumeMounts:
+            - name: ca
+              mountPath: {{.controlplaneCAMountPath}}
+              subPath: "ca"
+              readOnly: true
+            - name: tls
+              mountPath: {{.controlplaneCertMountPath}}
+              subPath: "cert"
+              readOnly: true
+            - name: tls
+              mountPath: {{.controlplaneKeyMountPath}}
+              subPath: "key"
+              readOnly: true
+            - name: cl-controlplane
+              mountPath: {{.persistencyDirectoryMountPath}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cl-dataplane
+  labels:
+    app: cl-dataplane
+spec:
+  replicas: {{.dataplanes}}
+  selector:
+    matchLabels:
+      app: cl-dataplane
+  template:
+    metadata:
+      labels:
+        app: cl-dataplane
+    spec:
+      volumes:
+        - name: ca
+          secret:
+            secretName: cl-fabric
+        - name: tls
+          secret:
+            secretName: cl-dataplane
+      containers:
+        - name: dataplane
+          image: cl-dataplane
+          imagePullPolicy: IfNotPresent
+          args: ["--controlplane-host", "cl-controlplane", "--log-level", "info"]
+          ports:
+            - containerPort: {{.dataplanePort}}
+          volumeMounts:
+            - name: ca
+              mountPath: {{.dataplaneCAMountPath}}
+              subPath: "ca"
+              readOnly: true
+            - name: tls
+              mountPath: {{.dataplaneCertMountPath}}
+              subPath: "cert"
+              readOnly: true
+            - name: tls
+              mountPath: {{.dataplaneKeyMountPath}}
+              subPath: "key"
+              readOnly: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gwctl
+  labels:
+    app: gwctl
+spec:
+  volumes:
+    - name: ca
+      secret:
+        secretName: cl-fabric
+    - name: tls
+      secret:
+        secretName: gwctl
+  containers:
+    - name: gwctl
+      image: gwctl
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh"]
+      args:
+        - -c
+        - >-
+            gwctl init --id {{.peer}} \
+                       --gwIP cl-dataplane \
+                       --gwPort {{.dataplanePort}} \
+                       --certca /root/ca.pem \
+                       --cert /root/cert.pem \
+                       --key /root/key.pem &&
+            gwctl config use-context --myid {{.peer}} &&
+            sleep infinity
+      volumeMounts:
+        - name: ca
+          mountPath: /root/ca.pem
+          subPath: "ca"
+          readOnly: true
+        - name: tls
+          mountPath: /root/cert.pem
+          subPath: "cert"
+          readOnly: true
+        - name: tls
+          mountPath: /root/key.pem
+          subPath: "key"
+          readOnly: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cl-controlplane
+spec:
+  selector:
+    app: cl-controlplane
+  ports:
+    - name: controlplane
+      port: {{.controlplanePort}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cl-dataplane
+spec:
+  selector:
+    app: cl-dataplane
+  ports:
+    - name: dataplane
+      port: {{.dataplanePort}}`
+)
+
+// CreateK8SConfig creates a kubernetes deployment file.
+func CreateK8SConfig(args map[string]interface{}, outDir string) error {
+	var k8sConfig bytes.Buffer
+	t := template.Must(template.New("").Parse(k8sTemplate))
+	if err := t.Execute(&k8sConfig, args); err != nil {
+		return fmt.Errorf("cannot create k8s configuration off template: %v", err)
+	}
+
+	outPath := filepath.Join(outDir, config.K8SYamlFile)
+	return os.WriteFile(outPath, k8sConfig.Bytes(), 0600)
+}

--- a/cmd/cl-adm/util/cert.go
+++ b/cmd/cl-adm/util/cert.go
@@ -1,0 +1,171 @@
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	mathrand "math/rand"
+	"os"
+	"time"
+)
+
+// CertificateConfig holds a configuration for creating a new signed certificate.
+type CertificateConfig struct {
+	// Name is the common name that will be used in the certificate.
+	Name string
+
+	// IsCA should be set to true if creating a CA certificate.
+	IsCA bool
+	// IsServer should be set to true if certificate should allow server authentication.
+	IsServer bool
+	// IsServer should be set to true if certificate should allow client authentication.
+	IsClient bool
+	// DNSNames are the DNS names to be set in the certificate.
+	// For a CA certificate, these are the permitted DNS names.
+	DNSNames []string
+
+	// CAPath is the path to the CA certificate that will sign the certificate.
+	// If empty, certificate will self-sign.
+	CAPath string
+	// CAKeyPath is the path to the private key of the CA that will sign the certificate.
+	CAKeyPath string
+
+	// CertOutPath is the path where the certificate will be saved to.
+	CertOutPath string
+	// CertOutPath is the path where the private key will be saved to.
+	PrivateKeyOutPath string
+}
+
+// CreateCertificate creates a signed certificate.
+func CreateCertificate(config *CertificateConfig) error {
+	// generate key pair
+	key, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return err
+	}
+
+	// RNG for generating certificate serial number.
+	//#nosec G404 -- certificate serial number does not need secure random
+	rng := mathrand.New(mathrand.NewSource(time.Now().UTC().UnixNano()))
+
+	// create certificate
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(rng.Int63()),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		IsCA:         config.IsCA,
+		Subject:      pkix.Name{CommonName: config.Name},
+	}
+
+	if config.IsCA {
+		cert.BasicConstraintsValid = true
+		cert.PermittedDNSDomains = config.DNSNames
+		cert.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	} else {
+		cert.DNSNames = config.DNSNames
+	}
+
+	if config.IsServer {
+		cert.ExtKeyUsage = append(cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	}
+
+	if config.IsClient {
+		cert.ExtKeyUsage = append(cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	}
+
+	var ca *x509.Certificate
+	var caKey *rsa.PrivateKey
+
+	if config.CAPath != "" {
+		// load CA certificate
+		rawCA, err := os.ReadFile(config.CAPath)
+		if err != nil {
+			return err
+		}
+
+		block, _ := pem.Decode(rawCA)
+		if block == nil {
+			return fmt.Errorf("CA certificate file is not in PEM format")
+		}
+
+		ca, err = x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return err
+		}
+
+		// load CA key
+		rawCAKey, err := os.ReadFile(config.CAKeyPath)
+		if err != nil {
+			return err
+		}
+
+		block, _ = pem.Decode(rawCAKey)
+		if block == nil {
+			return fmt.Errorf("CA key file is not in PEM format")
+		}
+
+		caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+	} else {
+		ca = cert
+		caKey = key
+	}
+
+	// sign certificate
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &key.PublicKey, caKey)
+	if err != nil {
+		return err
+	}
+
+	// PEM encode the private key
+	keyPEM := new(bytes.Buffer)
+	err = pem.Encode(keyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	if err != nil {
+		return err
+	}
+
+	// PEM encode the certificate
+	certPEM := new(bytes.Buffer)
+	err = pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	if err != nil {
+		return err
+	}
+
+	if ca != cert {
+		// append CA certificate
+		err = pem.Encode(certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: ca.Raw,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// save private key to file
+	err = os.WriteFile(config.PrivateKeyOutPath, keyPEM.Bytes(), 0600)
+	if err != nil {
+		return err
+	}
+
+	// save certificate to file
+	err = os.WriteFile(config.CertOutPath, certPEM.Bytes(), 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	golang.org/x/net v0.10.0
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0
 	inet.af/tcpproxy v0.0.0-20221017015627-91f861402626
@@ -55,7 +56,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect

--- a/tests/docker.sh
+++ b/tests/docker.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TEST_DIR=$(mktemp -d)
+CLADM=$SCRIPT_DIR/../bin/cl-adm
+
+function clean_up {
+  # delete containers
+  docker rm -f peer1-controlplane || true
+  docker rm -f peer1-dataplane || true
+  docker rm -f peer1-gwctl || true
+
+  # delete network
+  docker network rm peer1 || true
+
+  cd -
+}
+
+function test_docker {
+  # create fabric with a single peer (peer1)
+  $CLADM create fabric
+  $CLADM create peer --name peer1
+
+  # start containers
+  ./peer1/docker-run.sh
+
+  # connect all containers via network
+  docker network create peer1
+  docker network connect peer1 peer1-controlplane
+  docker network connect peer1 peer1-dataplane
+  docker network connect peer1 peer1-gwctl
+
+  # install iperf3 and jq
+  docker exec -it peer1-gwctl apk add iperf3 jq
+
+  # start iperf3 server
+  docker exec -itd peer1-gwctl iperf3 -s -p 1234
+
+  # wait for API server to come up
+  docker exec -it peer1-gwctl timeout 30 sh -c 'until gwctl get peer; do sleep 0.1; done > /dev/null 2>&1'
+
+  # export iperf server
+  docker exec -it peer1-gwctl gwctl create export --name foo --host peer1-gwctl --port 1234
+
+  # import
+  docker exec -it peer1-gwctl gwctl create peer --host peer1-dataplane --port 443 --name peer1
+  docker exec -it peer1-gwctl gwctl create import --name foo --host bla --port 9999
+  docker exec -it peer1-gwctl gwctl create binding --import foo --peer peer1
+
+  # get imported service port
+  PORT=$(docker exec -it peer1-gwctl /bin/bash -c "gwctl get import --name foo | jq '.Status.Listener.Port' | tr -d '\n'")
+
+  # wait for imported service socket to come up
+  docker exec -it peer1-gwctl timeout 30 sh -c 'until nc -z $0 $1; do sleep 0.1; done' peer1-dataplane $PORT
+  # wait for iperf server to come up
+  docker exec -it peer1-gwctl timeout 30 sh -c 'until nc -z $0 $1; do sleep 0.1; done' peer1-gwctl 1234
+
+  # run iperf client
+  docker exec -it peer1-gwctl iperf3 -c peer1-dataplane -p $PORT -t 1
+}
+
+cd $TEST_DIR
+clean_up
+
+trap clean_up INT TERM EXIT
+
+cd $TEST_DIR
+test_docker
+
+echo OK

--- a/tests/k8s.sh
+++ b/tests/k8s.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TEST_DIR=$(mktemp -d)
+CLADM=$SCRIPT_DIR/../bin/cl-adm
+
+function clean_up {
+  kind delete cluster --name peer1
+
+  cd -
+}
+
+function test_k8s {
+  # create fabric with a single peer (peer1)
+  $CLADM create fabric
+  $CLADM create peer --name peer1
+
+  # create kind cluster
+  kind create cluster --name peer1
+
+  # load images to cluster
+  kind load docker-image cl-controlplane cl-dataplane gwctl --name peer1
+
+  # configure kubectl
+  kubectl config use-context kind-peer1
+
+  # create clusterlink objects
+  kubectl create -f ./peer1/k8s.yaml
+
+  # wait for gwctl pod to run
+  kubectl wait --for=condition=ready pod/gwctl
+
+  # install iperf3 and jq
+  kubectl exec -it gwctl -- apk add iperf3 jq
+
+  # start iperf3 server
+  kubectl exec -it gwctl -- iperf3 -s -D -p 1234
+
+  # expose iperf3 server
+  kubectl expose pod gwctl --name=foo --port=80 --target-port=1234
+
+  # wait for API server to come up
+  kubectl exec -it gwctl -- timeout 30 sh -c 'until gwctl get peer; do sleep 0.1; done > /dev/null 2>&1'
+
+  # export iperf server
+  kubectl exec -it gwctl -- gwctl create export --name foo --host foo --port 80
+
+  # import
+  kubectl exec -it gwctl -- gwctl create peer --host cl-dataplane --port 443 --name peer1
+  kubectl exec -it gwctl -- gwctl create import --name foo --host bla --port 9999
+  kubectl exec -it gwctl -- gwctl create binding --import foo --peer peer1
+
+  # get imported service port
+  PORT=$(kubectl exec -it gwctl -- /bin/bash -c "gwctl get import --name foo | jq '.Status.Listener.Port' | tr -d '\n'")
+
+  # expose imported service (TODO: remove this when controlplane automatically creates a service)
+  kubectl expose deployment cl-dataplane --name=bla --port=9999 --target-port=$PORT
+
+  # wait for imported service socket to come up
+  kubectl exec -it gwctl -- timeout 30 sh -c 'until nc -z $0 $1; do sleep 0.1; done' bla 9999
+  # wait for iperf server to come up
+  kubectl exec -it gwctl -- timeout 30 sh -c 'until nc -z $0 $1; do sleep 0.1; done' gwctl 1234
+
+  # run iperf client
+  kubectl exec -it gwctl -- iperf3 -c bla -p 9999 -t 1
+}
+
+cd $TEST_DIR
+clean_up
+
+trap clean_up INT TERM EXIT
+
+cd $TEST_DIR
+test_k8s
+
+echo OK


### PR DESCRIPTION
This PR adds the cl-adm utility which is used for preparing a clusterlink deployment. It currently supports a docker-based deployment, and a k8s deployment.