### PR TITLE
util/log: Add logutills to the new controlplane

### DIFF
--- a/cmd/cl-controlplane/app/server.go
+++ b/cmd/cl-controlplane/app/server.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +15,7 @@ import (
 	"github.com/clusterlink-net/clusterlink/pkg/store/kv"
 	"github.com/clusterlink-net/clusterlink/pkg/store/kv/bolt"
 	"github.com/clusterlink-net/clusterlink/pkg/util"
+	logutils "github.com/clusterlink-net/clusterlink/pkg/util/log"
 	"github.com/clusterlink-net/clusterlink/pkg/util/sniproxy"
 )
 
@@ -58,27 +58,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 // Run the various controlplane servers.
 func (o *Options) Run() error {
 	// set log file
-	if o.LogFile != "" {
-		f, err := os.OpenFile(o.LogFile, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
-		if err != nil {
-			return fmt.Errorf("unable to open log file: %v", err)
-		}
 
-		defer func() {
-			if err := f.Close(); err != nil {
-				log.Errorf("Cannot close log file: %v", err)
-			}
-		}()
-
-		log.SetOutput(f)
-	}
-
-	// set log level
-	logLevel, err := log.ParseLevel(o.LogLevel)
-	if err != nil {
-		return fmt.Errorf("unable to set log level: %v", err)
-	}
-	log.SetLevel(logLevel)
+	logutils.SetLog(o.LogLevel, o.LogFile)
 
 	parsedCertData, err := util.ParseTLSFiles(CAFile, CertificateFile, KeyFile)
 	if err != nil {

--- a/cmd/controlplane/subcommand/start.go
+++ b/cmd/controlplane/subcommand/start.go
@@ -16,12 +16,12 @@ import (
 	"github.com/clusterlink-net/clusterlink/pkg/k8s/kubernetes"
 	metrics "github.com/clusterlink-net/clusterlink/pkg/metrics"
 	"github.com/clusterlink-net/clusterlink/pkg/policyengine"
-	"github.com/clusterlink-net/clusterlink/pkg/utils/logutils"
+	logutils "github.com/clusterlink-net/clusterlink/pkg/util/log"
 	"github.com/clusterlink-net/clusterlink/pkg/utils/netutils"
 )
 
 const (
-	logFileName = "gw.log"
+	logFileName = "/.gw/gw.log"
 )
 
 // StartCmd represents the start command of control plane
@@ -154,7 +154,11 @@ func addPolicyEngine(policyengineTarget string, start bool) {
 func createMbg(id, ip, cportLocal, cportExtern, localDataPortRange, externalDataPortRange, dataplane,
 	caFile, certificateFile, keyFile, logLevel string, logFile bool) {
 
-	logutils.SetLog(logLevel, logFile, logFileName)
+	if logFile {
+		logutils.SetLog(logLevel, logFileName)
+	} else {
+		logutils.SetLog(logLevel, "")
+	}
 	store.SetState(id, ip, cportLocal, cportExtern, localDataPortRange, externalDataPortRange, caFile, certificateFile, keyFile, dataplane)
 
 	// Set chi router
@@ -171,7 +175,11 @@ func createMbg(id, ip, cportLocal, cportExtern, localDataPortRange, externalData
 // restoreMbg restore the mbg after a failure in the control plane
 func restoreMbg(logLevel string, logFile, startPolicyEngine bool) {
 	store.UpdateState()
-	logutils.SetLog(logLevel, logFile, logFileName)
+	if logFile {
+		logutils.SetLog(logLevel, logFileName)
+	} else {
+		logutils.SetLog(logLevel, "")
+	}
 	if startPolicyEngine {
 		go addPolicyEngine("localhost"+store.GetMyCport().Local, true)
 	}

--- a/cmd/dataplane/main.go
+++ b/cmd/dataplane/main.go
@@ -11,11 +11,11 @@ import (
 
 	dp "github.com/clusterlink-net/clusterlink/pkg/dataplane"
 	"github.com/clusterlink-net/clusterlink/pkg/dataplane/store"
-	"github.com/clusterlink-net/clusterlink/pkg/utils/logutils"
+	logutils "github.com/clusterlink-net/clusterlink/pkg/util/log"
 )
 
 const (
-	logFileName = "dataplane.log"
+	logFileName = "/.gw/dataplane.log"
 )
 
 func main() {
@@ -34,7 +34,7 @@ func main() {
 	// Parse command-line flags
 	flag.Parse()
 	// Set log file
-	logutils.SetLog(logLevel, true, logFileName)
+	logutils.SetLog(logLevel, logFileName)
 	log.Infof("Dataplane main started")
 
 	if profilePort != 0 {

--- a/tests/e2e/iperf3/iperf3_test.go
+++ b/tests/e2e/iperf3/iperf3_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/clusterlink-net/clusterlink/pkg/api"
 	"github.com/clusterlink-net/clusterlink/pkg/client"
-	"github.com/clusterlink-net/clusterlink/pkg/utils/logutils"
+	logutils "github.com/clusterlink-net/clusterlink/pkg/util/log"
 	"github.com/clusterlink-net/clusterlink/tests/e2e/utils"
 )
 
@@ -37,7 +37,7 @@ var (
 
 // TestIperf3 check e2e iperf3 test
 func TestIperf3(t *testing.T) {
-	logutils.SetLog("info", false, "")
+	logutils.SetLog("info", "")
 	t.Run("Starting Cluster Setup", func(t *testing.T) {
 		err := utils.StartClusterSetup()
 		if err != nil {


### PR DESCRIPTION
Move logutils to the util/log folder and remove the boolean flag from the SetLog function.
Use logutils.SetLog for setting the log in the cl-controlplane.
