### PR TITLE
.github/workflows: Remove test check from e2e

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -25,7 +25,5 @@ jobs:
       run: make build
     - name: Build docker images
       run: make docker-build
-    - name: Run e2e connectivity test on a kind cluster
-      run: ./tests/k8s.sh
-    - name: Run end-to-end tests
+    - name: Run end-to-end tests (old control-plane)
       run: make tests-e2e


### PR DESCRIPTION
Remove tests/k8s.sh from the pr-check of e2e-test.