### PR TITLE
[open source]: add recommended CNCF project files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Please the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io)
+in order to report violations of the Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing Guide
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#introduction)
+
+* [New Contributor Guide](#contributing-guide)
+  * [Ways to Contribute](#ways-to-contribute)
+  * [Find an Issue](#find-an-issue)
+  * [Ask for Help](#ask-for-help)
+  * [Pull Request Lifecycle](#pull-request-lifecycle)
+  * [Development Environment Setup](#development-environment-setup)
+  * [Sign Your Commits](#sign-your-commits)
+  * [Pull Request Checklist](#pull-request-checklist)
+
+Welcome! We are glad that you want to contribute to our project! 💖
+
+As you get started, you are in the best position to give us feedback on areas of
+our project that we need help with including:
+
+* Problems found during setting up a new developer environment
+* Gaps in our Quickstart Guide or documentation
+* Bugs in our automation scripts
+
+If anything doesn't make sense, or doesn't work when you run it, please open a
+bug report and let us know!
+
+## Ways to Contribute
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#ways-to-contribute)
+
+We welcome many different types of contributions including:
+
+* New features
+* Builds, CI/CD
+* Bug fixes
+* Documentation
+* Issue Triage
+* Answering questions on Slack/Mailing List
+* Web design
+* Communications / Social Media / Blog Posts
+* Release management
+
+<!--
+Not everything happens through a GitHub pull request. Please come to our
+[meetings](TODO) or [contact us](TODO) and let's discuss how we can work
+together. -->
+
+<!--
+### Come to Meetings
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#come-to-meetings)
+
+Absolutely everyone is welcome to come to any of our meetings. You never need an
+invite to join us. In fact, we want you to join us, even if you don’t have
+anything you feel like you want to contribute. Just being there is enough!
+
+You can find out more about our meetings [here](TODO). You don’t have to turn on
+your video. The first time you come, introducing yourself is more than enough.
+Over time, we hope that you feel comfortable voicing your opinions, giving
+feedback on others’ ideas, and even sharing your own ideas, and experiences.
+-->
+
+## Find an Issue
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#find-an-issue)
+
+We have good first issues for new contributors and help wanted issues suitable
+for any contributor. [good first issue](TODO) has extra information to
+help you make your first contribution. [help wanted](TODO) are issues
+suitable for someone who isn't a core maintainer and is good to move onto after
+your first pull request.
+
+<!-- 
+Sometimes there won’t be any issues with these labels. That’s ok! There is
+likely still something for you to work on. If you want to contribute but you
+don’t know where to start or can't find a suitable issue, you can ⚠️ **explain how people can ask for an issue to work on**.
+-->
+
+Once you see an issue that you'd like to work on, please post a comment saying
+that you want to work on it. Something like "I want to work on this" is fine.
+
+## Ask for Help
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#ask-for-help)
+
+The best way to reach us with a question when contributing is to ask on:
+
+<!-- ⚠️ **Pick the way(s) that you prefer people ask for help** -->
+
+* The original github issue
+* The developer mailing list
+* Our Slack channel
+
+## Pull Request Lifecycle
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#pull-request-lifecycle)
+
+<!-- ⚠️ **Explain your pull request process** -->
+
+## Development Environment Setup
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#development-environment-setup)
+
+<!-- ⚠️ **Explain how to set up a development environment** -->
+
+## Sign Your Commits
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#sign-your-commits)
+
+### DCO
+
+Licensing is important to open source projects. It provides some assurances that
+the software will continue to be available based under the terms that the
+author(s) desired. We require that contributors sign off on commits submitted to
+our project's repositories. The [Developer Certificate of Origin
+(DCO)](https://probot.github.io/apps/dco/) is a way to certify that you wrote and
+have the right to contribute the code you are submitting to the project.
+
+You sign-off by adding the following to your commit messages. Your sign-off must
+match the git user and email associated with the commit.
+
+    This is my commit message
+
+    Signed-off-by: Your Name <your.name@example.com>
+
+Git has a `-s` command line option to do this automatically:
+
+    git commit -s -m 'This is my commit message'
+
+If you forgot to do this and have not yet pushed your changes to the remote
+repository, you can amend your commit with the sign-off by running 
+
+    git commit --amend -s 
+
+## Pull Request Checklist
+
+When you submit your pull request, or you push new commits to it, our automated
+systems will run some checks on your new code. We require that your pull request
+passes these checks, but we also have more criteria than just that before we can
+accept and merge it. We recommend that you check the following things locally
+before you submit your code:
+
+<!-- ⚠️ **Create a checklist that authors should use before submitting a pull request** -->

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,157 @@
+# ClusterLink Project Governance
+
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/governance-maintainer/)
+
+The ClusterLink project is dedicated to creating multicloud Service interconnect fabric.
+This governance explains how the project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifications](#modifying-this-charter)
+
+## Work In Progress
+
+This document is work in progress and has several incomplete items that need resolution.
+The items are mostly marked in the text as `[TODO:Some action]`:
+
+-[ ] Populate maintainers list
+-[ ] Decide on criteria for becoming a maintainer
+-[ ] Mailing list creation and management
+-[ ] Project meeting schedule
+-[ ] Security response team and issue handling
+
+## Values
+
+The ClusterLink and its leadership embrace the following values:
+
+- Openness: Communication and decision-making happens in the open and is discoverable for
+ future reference. As much as possible, all discussions and work take place in public
+ forums and open repositories.
+
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
+ contributions, which will be considered on their merits.
+
+- Community over Product or Company: Sustaining and growing our community takes
+ priority over shipping code or sponsors' organizational goals.  Each contributor
+ participates in the project as an individual.
+
+- Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+- Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+ClusterLink Maintainers have write access to the [clusterlink-net/clusterlink](https://github.com/clusterlink-net/clusterlink) repository.
+They can merge their own patches or patches from others. The current maintainers
+can be found in [MAINTAINERS.md](./MAINTAINERS.md). Maintainers collectively manage the
+project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the ClusterLink project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which
+is the governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate the following:
+
+- commitment to the project:
+  - participate in discussions, contributions, code and documentation reviews
+      for [TODO:Period] or more,
+  - perform reviews for [TODO:Number] non-trivial pull requests,
+  - contribute [TODO:Number] non-trivial pull requests and have them merged,
+- ability to write quality code and/or documentation,
+  - ability to collaborate with the team,
+  - understanding of how the team works (policies, processes for testing and code review, etc),
+  - understanding of the project's code base and coding and documentation style.
+  <!-- add any additional Maintainer requirements here -->
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[developer mailing list](TODO: List Link). A simple majority vote of existing Maintainers
+approves the application.  Maintainers nominations will be evaluated without prejudice
+to employer or demographics.
+
+Maintainers who are selected will be granted the necessary GitHub rights,
+and invited to the [private maintainer mailing list](TODO).
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their
+Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Inactivity is defined as a period of very low or no activity in the project
+for a year or more, with no definite schedule to return to full Maintainer
+activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus
+status.  Emeritus Maintainers will still be consulted on some project matters,
+and can be rapidly returned to Maintainer status if their availability changes.
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+developer meeting, which occurs
+[TODO: Details of regular developer or maintainer meeting here].  
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## Code of Conduct
+
+[Code of Conduct](./code-of-conduct.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](TODO). If a Maintainer is directly involved
+in the report, the Maintainers will instead designate two Maintainers to work
+with the CNCF Code of Conduct Committee in resolving it.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves.  If this
+responsibility is delegated, the Maintainers will appoint a team of at least two
+contributors to handle it.  The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](TODO:Link to security.md).
+
+## Voting
+
+While most business in ClusterLink is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
+periodically the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](TODO) or
+[the private Maintainer mailing list](TODO) for security or conduct matters.  
+Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
+demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where
+otherwise noted.  Two-thirds majority votes mean at least two-thirds of all
+existing maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by
+a 2/3 vote of the Maintainers.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+# Maintainers
+
+The current Maintainers Group for the ClusterLink Project consists of:
+
+| Name | Employer | Responsibilities |
+| ---- | -------- | ---------------- |
+|      |          |                  |
+
+<!-- This list must be kept in sync with the [Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv). -->
+
+See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the old name (directly or using the `MBG` acronym). We're in the process of chan
 
 ## What Is ClusterLink?
 
+<!-- Mission Statement -->
+<!-- More information about crafting your mission statement with examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+<!-- [TODO: PROJECTNAME] is a [TODO: Type of Tool] that [TODO: Functions it
+performs].  [TODO: Reasons why these are needed and valuable].  [TODO:
+Implementation, strategy and architecture].
+
+[TODO: Additional paragraph describing your project (optional)] -->
+
 The ClusterLink project simplifies the connection between application services that are located in different domains, networks, and cloud infrastructures.
 
 For more details, see the document: [ClusterLink extended abstract](docs/ClusteLink.pdf).
@@ -33,11 +43,24 @@ The ClusterLink APIs use the following entities for configuring cross cluster co
 * Imported service. Represent remote application services that the gateway makes available locally to clients inside its cluster.
 * Policy. Represent communication rules that must be enforced for all cross-cluster communications at each ClusterLink gateway.
 
-## How to setup and run ClusterLink
+## Getting Started
+
+<!-- Include enough details to get started using, or at least building, the
+project here and link to other docs with more detail as needed.  Depending on
+the nature of the project and its current development status, this might
+include:
+* quick installation/build instructions
+* a few simple examples of use
+* basic prerequisites
+-->
+
+WIP; combine with sections below. Some details should probably be moved into their own documents.
+
+### How to setup and run ClusterLink
 
 ClusterLink can be set up and run on different environments: local environment (Kind), Bare-metal environment, or cloud environment.
 
-### Run ClusterLink in local environment (Kind)
+#### Run ClusterLink in local environment (Kind)
 
 ClusterLink can run in any K8s environment, such as Kind.
 To run the ClusterLink in a Kind environment, follow one of the examples:
@@ -45,10 +68,74 @@ To run the ClusterLink in a Kind environment, follow one of the examples:
 1) Performance example - Run iPerf3 test between iPerf3 client and server using ClusterLink components. This example is used for performance measuring. Instructions can be found [Here](demos/iperf3/kind/README.md).
 1) Application example - Run the BookInfo application in different clusters using ClusterLink components. This example demonstrates communication distributed applications (in different clusters) with different policies.Instructions can be found [Here](demos/bookinfo/kind/README.md).
 
-### Run ClusterLink in Bare-metal environment with 2 hosts
+#### Run ClusterLink in Bare-metal environment with 2 hosts
 
 TBD
 
-### Run ClusterLink in cloud environment
+#### Run ClusterLink in cloud environment
 
 TBD
+
+## Contributing
+<!-- Template: https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md -->
+
+Our project welcomes contributions from any member of our community. To get
+started contributing, please see our [Contributor Guide](TODO: Link to
+CONTRIBUTING.md).
+
+## Scope
+<!-- If this section is too long, you might consider moving it to a SCOPE.md -->
+<!-- More information about creating your scope with links to examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+### In Scope
+
+[TODO: PROJECTNAME] is intended to [TODO: Core functionality]. As such, the
+project will implement or has implemented:
+
+* [TODO: High-level Item 1]
+* [TODO: High-level Item 2]
+* [TODO: High-level Item 3]
+
+### Out of Scope
+
+[TODO: PROJECTNAME] will be used in a cloud native environment with other
+tools. The following specific functionality will therefore not be incorporated:
+
+* [TODO: Excluded function 1]
+* [TODO: Excluded function 2]
+
+[TODO: PROJECTNAME] implements [TODO: List of major features, existing or
+planned], through [TODO: Implementation
+requirements/language/architecture/etc.]. It will not cover [TODO: short list
+of excluded items]
+
+## Communications
+
+<!-- Fill in the communications channels you actually use.  These should all be public channels anyone
+can join, and there should be several ways that users and contributors can reach project maintainers. 
+If you have recurring/regular meetings, list those or a link to a publicy-readable calendar so that
+prospective contributors know when and where to engage with you. -->
+
+[TODO: Details (with links) to meetings, mailing lists, Slack, and any other communication channels]
+
+* User Mailing List:
+* Developer Mailing List:
+* Slack Channel:
+* Public Meeting Schedule and Links: 
+* Social Media:
+* Other Channel(s), If Any:
+
+## Resources
+
+[TODO: Add links to other helpful information (roadmap, docs, website, etc.)]
+
+## License
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/LICENSE -->
+This project is licensed under [TODO: Add name of license and link to your LICENSE file]
+
+## Conduct
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md -->
+We follow the CNCF Code of Conduct [TODO: Insert link to your CODE_OF_CONDUCT.md file].

--- a/design-proposals/DESIGN-PROPOSALS-template.md
+++ b/design-proposals/DESIGN-PROPOSALS-template.md
@@ -1,0 +1,192 @@
+# Design Proposal Template
+
+**Authors**: [alice](mailto:alice@example.com), [bob jones](mailto:bob@example.com)
+
+**Begin Design Discussion**: YYYY-MM-DD
+
+**(optional) Status:** implementable, accepted, deferred, rejected, withdrawn, or replaced
+
+**Checklist**:
+
+What goes in this checklist is highly dependent on how your project manages their PRs.
+ The Checklist is intended to serve as a final review for the feature before cutting the
+ release where the feature is available.
+
+- [ ] Prerequisite 1
+- [ ] Prerequisite 2
+- [ ] Component 1
+- [ ] Component 2
+- [ ] Docs
+- [ ] Tests
+
+## Summary/Abstract
+
+Provide a high-level summary of the proposed change. Keep it short.
+
+This design process establishes a series of standard practices for planning and recording
+ features or changes proposed for the project. The intent is to provide the project a
+ consistent means to track decisions for historical reference and future plans while
+ fully capturing how the feature or change will come to be. Additional benefits include
+ making the process of building the release changelog easier and faster when the feature
+ or change is ready to be released. It is a combination of a feature and effort-tracking
+ document, a product requirements document, and a design document.
+
+## Background
+
+### Motivation and problem space
+
+Describe the need, problem, and motivation for the feature or change and any context
+ required to understand the motivation.
+
+### Impact and desired outcome
+
+Describe any potential impact this feature or change would have. Readers should be able
+ to understand why the feature or change is important. Briefly describe the desired
+ outcome if the change or feature were implemented as designed.
+
+### Prior discussion and links
+
+Often these proposals start as an issue, forum post, email and it's helpful to link to
+ those resources in this section to provide context and credit the right people for the
+ idea.
+
+It is vital for projects to be able to track the chain of custody for a proposed
+ enhancement from conception through implementation which can sometimes be difficult to
+ do in a single Github issue, especially when it is a larger design decision or cuts
+ across multiple areas of the project.
+
+The purpose of the design proposal processes is to reduce the amount of "siloed
+ knowledge" in a community. By moving decisions from a smattering of mailing lists, video
+ calls, slack messages, GitHub exchanges, and hallway conversations into a well tracked
+ artifact, the process aims to enhance communication and discoverability.
+
+## (Optional) User/User Story
+
+Define who your the intended users of the feature or change are. Detail the things that
+ your users will be able to do with the feature if it is implemented. Include as much
+ detail as possible so that people can understand the "how" of the system. This can also
+ be combined with the prior sections.
+
+## Goals
+
+List the desired goal or goals that the design is intended to achieve. These goals can be
+ leveraged to structure and scope the design and discussions and may be reused as the
+ "definition of done" -  the criteria you use to know the implementation of the design
+ has succeeded in accomplishing its goals.
+
+## Non-Goals
+
+Describe what is out of scope for the design proposal. Listing non-goals helps to focus
+ discussion and make progress.
+
+## Proposal
+
+This is where we get down to the specifics of what the proposal actually is. It should
+ have enough detail that reviewers can understand exactly what you're proposing, but
+ should not include things like API designs or implementation. This section should expand
+ on the desired outcome and include details on how to measure success.
+
+## Design Details
+
+This section should contain enough information to allow the following to occur:
+
+- potential contributors understand how the feature or change should be implemented
+- users or operators understand how the feature of change is expected to function and
+ interact with other components of the project
+- users or operators can take action to pre-plan any needed changes within their
+ architecture that impacted by the upcoming feature or change if it's approved for
+ implementation
+- decisions or opinions on a specific approach are fully discussed and explained
+- users, operators, and contributors can gain a comprehensive understanding of
+ compatibility of the feature or change with past releases of the project.
+
+This may include API specs (though not always required), code snippets, data flow
+ diagrams, sequence diagrams, etc.
+
+If there's any ambiguity about HOW your proposal will be implemented, this is the place
+ to discuss them. This can also be combined with the proposal section above. It should
+ also address how the solution is backward compatible and how to deal with these
+ incompatibilities, possibly with defaulting or migrations. It may be useful to refer
+ back to the goals and non-goals to assist in articulating the "why" behind your approach.
+
+## Impacts / Key Questions
+
+List crucial impacts and key questions, some of which may still be open. They likely
+ require discussion and are required to understand the trade-offs of the design. During
+ the lifecycle of a design proposal, discussion on design aspects can be moved into this
+ section. After reading through this section, it should be possible to understand any
+ potentially negative or controversial impact of the design. It should also be possible
+ to derive the key design questions: X vs Y.
+
+This will also help people understand the caveats to the proposal, other important
+ details that didn't come across above, and alternatives that could be considered. It can
+ also be a good place to talk about core concepts and how they relate. It can be helpful
+ to explicitly list the pros and cons of each decision. Later, this information can be
+ reused to update project documentation, guides, and Frequently Asked Questions (FAQs).
+
+### Pros
+
+Pros are defined as the benefits and positive aspects of the design as described. It
+ should further reinforce how and why the design meets its goals and intended outcomes.
+ This is a good place to check for any assumptions that have been made in the design.
+
+### Cons
+
+Cons are defined as the negative aspects or disadvantages of the design as described.
+ This section has the potential to capture outstanding challenge areas or future
+ improvements needed for the project and could be referenced in future PRs and issues.
+ This is also a good place to check for any assumptions that have been made in the design.
+
+## Risks and Mitigations
+
+Describe the risks of this proposal and how they can be mitigated. This should be broadly
+ scoped and describe how it will impact the larger ecosystem and potentially adopters of
+ the project; such as if adopters need to immediately update, or support a new port or
+ protocol. It should include drawbacks to the proposed solution.
+
+### Security Considerations
+
+When attempting to identify security implications of the changes, consider the following questions:
+
+- Does the change alter the permissions or access of users, services, components - this
+ could be an improvement or downgrade or even just a different way of doing it?
+- Does the change alter the flow of information, events, and logs stored, processed, or
+ transmitted?
+- Does the change increase the 'surface area' exposed - meaning, if an operator of the
+ project or user were to go rogue or be uninformed in its operation, do they have more
+ areas that could be manipulated unfavorably?
+- What existing security features, controls, or boundaries would be affected by this
+ change?
+
+This section can also be combined into the one above.
+
+## (Optional) Future Milestones
+
+List things that the design will enable but that are out of scope for now. This can help
+ understand the greater impact of a proposal without requiring to extend the scope of a
+ proposal unnecessarily.
+
+## (Optional) Implementation Details
+
+Some projects may desire to track the implementation details in the design proposal. Some
+ sections may include:
+
+### Testing Plan
+
+An overview on the approaches used to test the implementation.
+
+### Update/Rollback Compatibility
+
+How the design impacts update compatibility and how users can test rollout and rollback.
+
+### Scalability
+
+Describe how the design scales, especially how changes API calls, resource usage, or
+ impacts SLI/SLOs.
+
+### Implementation Phases/History
+
+Describe the development and implementation phases planned to break up the work and/or
+ record them here as they occur. Provide enough detail so readers may track the major
+ milestones in the lifecycle of the design proposal and correlate them with issues, PRs,
+ and releases occurring within the project.


### PR DESCRIPTION
Add project files based off of CNCF template project

- License
- Governance
- Maintainers
- Contribution guide
- README sections

Some content is still work in progress and tracked in #50 