### PR TITLE
tests/iperf3 : support new control plane for k8s tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,17 @@ clean-tests:
 #------------------------------------------------------
 # Run Targets
 #------------------------------------------------------
+CP ?= old
+
 unit-tests:
 	@echo "Running unit tests..."
 	$(GO) test -v -count=1 ./pkg/...  -json -cover | tparse --all
 
-tests-e2e: clean-tests 	docker-build 
-	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/connectivity/...
+tests-e2e: build docker-build
+	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/connectivity/... --controlplane=$(CP)
 
-tests-iperf3: clean-tests 	docker-build 
-	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/iperf3/...
+tests-iperf3: build docker-build 
+	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/iperf3/... --controlplane=$(CP)
 
 run-gwctl:
 	@./bin/gwctl

--- a/Makefile
+++ b/Makefile
@@ -85,17 +85,15 @@ clean-tests:
 #------------------------------------------------------
 # Run Targets
 #------------------------------------------------------
-CP ?= old
-
 unit-tests:
 	@echo "Running unit tests..."
 	$(GO) test -v -count=1 ./pkg/...  -json -cover | tparse --all
 
 tests-e2e: build docker-build
-	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/connectivity/... --controlplane=$(CP)
+	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/connectivity/... 
 
 tests-iperf3: build docker-build 
-	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/iperf3/... --controlplane=$(CP)
+	$(GO) test -p 1 -timeout 30m -v -tags e2e ./tests/e2e/iperf3/...
 
 run-gwctl:
 	@./bin/gwctl

--- a/tests/e2e/connectivity/basic_test.go
+++ b/tests/e2e/connectivity/basic_test.go
@@ -31,7 +31,7 @@ var (
 	gwctl2             *client.Client
 )
 
-var cpType = flag.String("controlplane", "old", "Check which control-plane to use")
+var cpType = flag.String("controlplane", "new", "Check which control-plane to use")
 
 func TestConnectivity(t *testing.T) {
 	t.Run("Starting Cluster Setup", func(t *testing.T) {

--- a/tests/e2e/connectivity/basic_test.go
+++ b/tests/e2e/connectivity/basic_test.go
@@ -1,6 +1,7 @@
 package connectivity
 
 import (
+	"flag"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,9 +31,11 @@ var (
 	gwctl2             *client.Client
 )
 
+var cpType = flag.String("controlplane", "old", "Check which control-plane to use")
+
 func TestConnectivity(t *testing.T) {
 	t.Run("Starting Cluster Setup", func(t *testing.T) {
-		err := utils.StartClusterSetup()
+		err := utils.StartClusterSetup(*cpType)
 		if err != nil {
 			t.Fatalf("Failed to setup cluster")
 		}
@@ -51,11 +54,11 @@ func TestConnectivity(t *testing.T) {
 			t.Fatalf("Failed to CreateK8sService")
 		}
 
-		gwctl1, err = utils.GetClient(gw1Name)
+		gwctl1, err = utils.GetClient(gw1Name, *cpType)
 		if err != nil {
 			t.Fatalf("Failed to get Client")
 		}
-		gwctl2, err = utils.GetClient(gw2Name)
+		gwctl2, err = utils.GetClient(gw2Name, *cpType)
 		if err != nil {
 			t.Fatalf("Failed to get Client")
 		}

--- a/tests/e2e/connectivity/basic_test.go
+++ b/tests/e2e/connectivity/basic_test.go
@@ -98,11 +98,17 @@ func TestConnectivity(t *testing.T) {
 	})
 	t.Run("Testing Service Connectivity", func(t *testing.T) {
 		policy, err := utils.GetPolicyFromFile(allowAllPolicyFile)
-		require.NoError(t, err)
-		err = gwctl1.SendAccessPolicy(policy, client.Add)
-		require.NoError(t, err)
-		err = gwctl2.SendAccessPolicy(policy, client.Add)
-		require.NoError(t, err)
+		if *cpType == "new" {
+			err = gwctl1.Policies.Create(policy)
+			require.NoError(t, err)
+			err = gwctl2.Policies.Create(policy)
+			require.NoError(t, err)
+		} else {
+			err = gwctl1.SendAccessPolicy(policy, client.Add)
+			require.NoError(t, err)
+			err = gwctl2.SendAccessPolicy(policy, client.Add)
+			require.NoError(t, err)
+		}
 
 		err = utils.UseKindCluster(gw2Name)
 		require.NoError(t, err)

--- a/tests/e2e/iperf3/iperf3_test.go
+++ b/tests/e2e/iperf3/iperf3_test.go
@@ -36,7 +36,7 @@ var (
 	gwctl2             *client.Client
 )
 
-var cpType = flag.String("controlplane", "old", "Check which control-plane to use")
+var cpType = flag.String("controlplane", "new", "Check which control-plane to use")
 
 // TestIperf3 check e2e iperf3 test
 func TestIperf3(t *testing.T) {

--- a/tests/e2e/iperf3/iperf3_test.go
+++ b/tests/e2e/iperf3/iperf3_test.go
@@ -101,10 +101,18 @@ func TestIperf3(t *testing.T) {
 	t.Run("Testing policy", func(t *testing.T) {
 		policy, err := utils.GetPolicyFromFile(allowAllPolicyFile)
 		require.NoError(t, err)
-		err = gwctl1.SendAccessPolicy(policy, client.Add)
-		require.NoError(t, err)
-		err = gwctl2.SendAccessPolicy(policy, client.Add)
-		require.NoError(t, err)
+		if *cpType == "new" {
+			err = gwctl1.Policies.Create(policy)
+			require.NoError(t, err)
+			err = gwctl2.Policies.Create(policy)
+			require.NoError(t, err)
+		} else {
+			err = gwctl1.SendAccessPolicy(policy, client.Add)
+			require.NoError(t, err)
+			err = gwctl2.SendAccessPolicy(policy, client.Add)
+			require.NoError(t, err)
+		}
+
 	})
 	t.Run("Testing Service Connectivity", func(t *testing.T) {
 		mbg2Ip, _ := utils.GetKindIP(gw2Name)

--- a/tests/e2e/iperf3/iperf3_test.go
+++ b/tests/e2e/iperf3/iperf3_test.go
@@ -7,6 +7,7 @@
 package iperf3_test
 
 import (
+	"flag"
 	"log"
 	"strconv"
 	"testing"
@@ -35,12 +36,14 @@ var (
 	gwctl2             *client.Client
 )
 
+var cpType = flag.String("controlplane", "old", "Check which control-plane to use")
+
 // TestIperf3 check e2e iperf3 test
 func TestIperf3(t *testing.T) {
 	_, err := logutils.SetLog("info", "")
 	require.NoError(t, err)
 	t.Run("Starting Cluster Setup", func(t *testing.T) {
-		err := utils.StartClusterSetup()
+		err := utils.StartClusterSetup(*cpType)
 		if err != nil {
 			t.Fatalf("Failed to setup cluster")
 		}
@@ -54,11 +57,11 @@ func TestIperf3(t *testing.T) {
 			t.Fatalf("Failed to LaunchApp iperf3 server mlabbe/iperf3")
 		}
 
-		gwctl1, err = utils.GetClient(gw1Name)
+		gwctl1, err = utils.GetClient(gw1Name, *cpType)
 		if err != nil {
 			t.Fatalf("Failed to get Client")
 		}
-		gwctl2, err = utils.GetClient(gw2Name)
+		gwctl2, err = utils.GetClient(gw2Name, *cpType)
 		if err != nil {
 			t.Fatalf("Failed to get Client")
 		}

--- a/tests/e2e/utils/kind.go
+++ b/tests/e2e/utils/kind.go
@@ -140,11 +140,6 @@ func createCluster(name string) (string, error) {
 		return "", err
 	}
 
-	err = runCmd("kind load docker-image mbg --name=" + name)
-	if err != nil {
-		return "", err
-	}
-
 	ip, err := GetKindIP(name)
 	return ip, err
 }
@@ -155,58 +150,101 @@ func DeleteCluster(name string) error {
 }
 
 // StartClusterLink creates a cluster, and launches clusterlink
-func StartClusterLink(name, cPortLocal, manifests string, cPort uint16) error {
+func StartClusterLink(name, cPortLocal, manifests string, cPort uint16, cpType string) error {
 	certs := "./mtls"
+	cPortStr := strconv.Itoa(int(cPort))
 	clusterIP, err := createCluster(name)
 	if err != nil {
 		return err
 	}
 
-	err = runCmd("kubectl apply -f " + manifests + "mbg-role.yaml")
-	if err != nil {
-		return err
-	}
+	if cpType == "new" {
+		clAdm := ProjDir + "/bin/cl-adm "
+		err := runCmdInDir(clAdm+" create peer --name "+name, testOutputFolder)
+		if err != nil {
+			return err
+		}
 
-	err = runCmd("kubectl create -f " + manifests + "mbg.yaml")
-	if err != nil {
-		return err
-	}
+		err = runCmd("kind load docker-image cl-controlplane cl-dataplane --name=" + name)
+		if err != nil {
+			return err
+		}
 
-	err = runCmd("kubectl create -f " + manifests + "dataplane.yaml")
-	if err != nil {
-		return err
-	}
+		err = runCmd("kubectl apply -f " + testOutputFolder + name + "/k8s.yaml")
+		if err != nil {
+			return err
+		}
 
-	err = IsPodReady("mbg")
-	if err != nil {
-		return err
-	}
+		err = IsPodReady("cl-dataplane")
+		if err != nil {
+			return err
+		}
+		err = runCmd("kubectl delete service cl-dataplane")
+		if err != nil {
+			return err
+		}
 
-	gwPod, _ := GetPodNameIP("mbg")
-	err = IsPodReady("dataplane")
-	if err != nil {
-		return err
-	}
+		err = runCmd("kubectl create service nodeport cl-dataplane --tcp=" + cPortLocal + ":" + cPortLocal + " --node-port=" + cPortStr)
+		if err != nil {
+			return err
+		}
 
-	dpPod, _ := GetPodNameIP("dataplane")
-	cPortStr := strconv.Itoa(int(cPort))
-	err = runCmd("kubectl create service nodeport dataplane --tcp=" + cPortLocal + ":" + cPortLocal + " --node-port=" + cPortStr)
-	if err != nil {
-		return err
-	}
+		err = runCmd("kubectl apply -f " + manifests + "mbg-role.yaml")
+		if err != nil {
+			return err
+		}
+	} else {
+		err = runCmd("kind load docker-image mbg --name=" + name)
+		if err != nil {
+			return err
+		}
 
-	startcmd := gwPod + " -- ./controlplane start --id " + name + " --ip " + clusterIP +
-		" --cport " + cPortStr + " --cportLocal " + cPortLocal + " --certca " + certs + "/ca.crt --cert " +
-		certs + "/" + name + ".crt --key " + certs + "/" + name + ".key"
-	err = runCmdB("kubectl exec -i " + startcmd)
-	if err != nil {
-		return err
-	}
+		err = runCmd("kubectl apply -f " + manifests + "mbg-role.yaml")
+		if err != nil {
+			return err
+		}
 
-	err = runCmdB("kubectl exec -i " + dpPod + " -- ./dataplane --id " + name + " --certca " + certs + "/ca.crt --cert " +
-		certs + "/" + name + ".crt --key " + certs + "/" + name + ".key")
-	if err != nil {
-		return err
+		err = runCmd("kubectl create -f " + manifests + "mbg.yaml")
+		if err != nil {
+			return err
+		}
+
+		err = runCmd("kubectl create -f " + manifests + "dataplane.yaml")
+		if err != nil {
+			return err
+		}
+
+		err = IsPodReady("mbg")
+		if err != nil {
+			return err
+		}
+
+		gwPod, _ := GetPodNameIP("mbg")
+		err = IsPodReady("dataplane")
+		if err != nil {
+			return err
+		}
+
+		err = runCmd("kubectl create service nodeport dataplane --tcp=" + cPortLocal + ":" + cPortLocal + " --node-port=" + cPortStr)
+		if err != nil {
+			return err
+		}
+
+		dpPod, _ := GetPodNameIP("dataplane")
+
+		startcmd := gwPod + " -- ./controlplane start --id " + name + " --ip " + clusterIP +
+			" --cport " + cPortStr + " --cportLocal " + cPortLocal + " --certca " + certs + "/ca.crt --cert " +
+			certs + "/" + name + ".crt --key " + certs + "/" + name + ".key"
+		err = runCmdB("kubectl exec -i " + startcmd)
+		if err != nil {
+			return err
+		}
+
+		err = runCmdB("kubectl exec -i " + dpPod + " -- ./dataplane --id " + name + " --certca " + certs + "/ca.crt --cert " +
+			certs + "/" + name + ".crt --key " + certs + "/" + name + ".key")
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/tests/e2e/utils/kind.go
+++ b/tests/e2e/utils/kind.go
@@ -175,6 +175,11 @@ func StartClusterLink(name, cPortLocal, manifests string, cPort uint16, cpType s
 			return err
 		}
 
+		err = IsPodReady("cl-controlplane")
+		if err != nil {
+			return err
+		}
+
 		err = IsPodReady("cl-dataplane")
 		if err != nil {
 			return err

--- a/tests/e2e/utils/kind.go
+++ b/tests/e2e/utils/kind.go
@@ -165,7 +165,7 @@ func StartClusterLink(name, cPortLocal, manifests string, cPort uint16, cpType s
 			return err
 		}
 
-		err = runCmd("kind load docker-image cl-controlplane cl-dataplane --name=" + name)
+		err = runCmd("kind load docker-image cl-controlplane cl-dataplane cl-go-dataplane --name=" + name)
 		if err != nil {
 			return err
 		}
@@ -194,10 +194,6 @@ func StartClusterLink(name, cPortLocal, manifests string, cPort uint16, cpType s
 			return err
 		}
 
-		err = runCmd("kubectl apply -f " + manifests + "mbg-role.yaml")
-		if err != nil {
-			return err
-		}
 	} else {
 		err = runCmd("kind load docker-image mbg --name=" + name)
 		if err != nil {


### PR DESCRIPTION
Allow to run the iperf3 test and e2e connectivity test with the new controlplane.