### PR TITLE
cmd/gwctl: Add get all command

### DIFF
--- a/cmd/gwctl/main.go
+++ b/cmd/gwctl/main.go
@@ -79,5 +79,6 @@ func getCmd() *cobra.Command {
 	getCmd.AddCommand(subcommand.BindingGetCmd())
 	getCmd.AddCommand(subcommand.PolicyGetCmd())
 	getCmd.AddCommand(subcommand.MetricsGetCmd())
+	getCmd.AddCommand(subcommand.AllGetCmd())
 	return getCmd
 }


### PR DESCRIPTION
Add get all commands that prints all: peers, imports, exports, bindings and policies.