### PR TITLE
cicd: Enable additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,8 +16,7 @@ linters:
   # set to true to run only fast linters (e.g., for pre-commit)
   fast: false
 
-  disable-all: false
-
+  disable-all: true
   enable:
     - asasalint
     - asciicheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,15 +45,15 @@ linters:
     - importas
     - ineffassign
     - makezero
-    # - misspell
+    - misspell
     - nakedret
     # - nestif
     - nilerr
     # - nilnil
     # - noctx
     # - nolintlint
-    # - nonamedreturns
-    # - nosprintfhostport
+    - nonamedreturns
+    - nosprintfhostport
     - prealloc
     - predeclared
     - promlinter
@@ -76,20 +76,19 @@ linters:
 linters-settings:
   gocritic:
     enabled-tags:
-      # - diagnostic
+      - diagnostic
       # - experimental
       # - opinionated
       - performance
       # - style
     disabled-checks:
-      # These 3 will detect many cases, but they do make sense in 
-      # performance oriented code
+      # consider enabling in performance oriented code
       - hugeParam
       - rangeExprCopy
       - rangeValCopy
 
-  # errcheck:
-    # change some error checks which are false by default
+  errcheck:
+    # change some error checks which are disabled by default
     # check-type-assertions: true
     # check-blank: true
     # exclude-functions:
@@ -137,6 +136,6 @@ issues:
   # nothing should be skipped to not miss errors.
   max-same-issues: 0
   # analyze only new code (manually set to false to check existing code)
-  new: false
+  new: true
   # do not automatically fix (until AI assisted code improves)
   fix: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,29 +1,142 @@
+# Based on recommendations in https://olegk.dev/go-linters-configuration-the-right-version
+
 run:
+  # linter execution
   timeout: 30m
+  issues-exit-code: 1
+  concurrency: 4
+  # check tests as well
+  tests: true
+  # fail if go.mod file is outdated.
+  modules-download-mode: readonly
+  # use the Go version from the go.mod file.
+  go: ""
 
 linters:
+  # set to true to run only fast linters (e.g., for pre-commit)
+  fast: false
+
   disable-all: false
+
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
     - bodyclose
-    - errcheck
+    - contextcheck
+    - durationcheck
+    - errcheck 
+    - errname
+    # - errorlint
     - exportloopref
-    - gosec
-    - gosimple
     - ginkgolinter
     - gocritic
+    # - godot
+    - gofmt
+    # - gofumpt
+    - goimports
+    - gomoddirectives
+    - gosec
+    - gosimple
     - govet
+    - grouper
+    # - lll
+    - loggercheck
+    - importas
     - ineffassign
+    - makezero
+    # - misspell
+    - nakedret
+    # - nestif
+    - nilerr
+    # - nilnil
+    # - noctx
+    # - nolintlint
+    # - nonamedreturns
+    # - nosprintfhostport
     - prealloc
+    - predeclared
+    - promlinter
+    - reassign
     - revive
     - staticcheck
     - stylecheck
+    # - tagliatelle
+    - tenv
+    - testableexamples
+    # - thelper
+    # - testpackage
+    - tparallel
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    # - varnamelen
 
 linters-settings:
   gocritic:
+    enabled-tags:
+      # - diagnostic
+      # - experimental
+      # - opinionated
+      - performance
+      # - style
+    disabled-checks:
+      # These 3 will detect many cases, but they do make sense in 
+      # performance oriented code
+      - hugeParam
+      - rangeExprCopy
+      - rangeValCopy
+
+  # errcheck:
+    # change some error checks which are false by default
+    # check-type-assertions: true
+    # check-blank: true
+    # exclude-functions:
+      # - io/ioutil.ReadFile
+      # - io.Copy(*bytes.Buffer)
+      # - io.Copy(os.Stdout)
+
+  govet:
+    disable:
+      - fieldalignment
+
+  nakedret:
+    # No naked returns (default: 30)
+    max-func-lines: 1
+
   staticcheck:
     checks:
       - "all"
+
   stylecheck:
+
+  tagliatelle:
+    case:
+      rules:
+        json: snake
+        yaml: snake
+        xml: camel
+        bson: camel
+        avro: snake
+        mapstructure: kebab
+
+output:
+  # prefer the simplest output: `line-number` without saving to file
+  format: line-number
+  print-issued-lines: false
+  print-linter-name: true
+  # allow multiple reports per line
+  uniq-by-line: false
+  # easier to follow the results with a deterministic output
+  sort-results: true
+
+issues:
+  # setting 0 to have all the results.
+  max-issues-per-linter: 0
+  # nothing should be skipped to not miss errors.
+  max-same-issues: 0
+  # analyze only new code (manually set to false to check existing code)
+  new: false
+  # do not automatically fix (until AI assisted code improves)
+  fix: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(SW_VERSION)
 # Target: clean
 #-----------------------------------------------------------------------------
 .PHONY: clean
-clean: ; $(info $(M) cleaning...)	@
+clean: ; $(info cleaning previous builds...)	@
 	@rm -rf ./bin
 
 #------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ format: fmt
 fmt: format-go tidy-go vet-go
 vet: vet-go
 
-lint:  ; $(info $(M) running linters...)
-	@golangci-lint run
+lint:  ; $(info running linters...)
+	@golangci-lint run --config=./.golangci.yaml ./...
 
-tidy-go: ; $(info $(M) tidying up go.mod...)
+tidy-go: ; $(info tidying up go.mod...)
 	@go mod tidy
 
-format-go: tidy-go vet-go ; $(info $(M) formatting code...)
+format-go: tidy-go vet-go ; $(info formatting code...)
 	@goimports -l -w .
 
-vet-go: ; $(info $(M) vetting code...)
+vet-go: ; $(info vetting code...)
 	@go vet ./...
 
 #------------------------------------------------------

--- a/pkg/controlplane/store/store.go
+++ b/pkg/controlplane/store/store.go
@@ -139,7 +139,7 @@ func GetDataplane() string {
 func GetDataplaneEndpoint() string {
 	return s.MyInfo.DataplaneEndpoint
 }
-func GetChiRouter() (r *chi.Mux) {
+func GetChiRouter() *chi.Mux {
 	return ChiRouter
 }
 

--- a/pkg/k8s/kubernetes/kubeinformer.go
+++ b/pkg/k8s/kubernetes/kubeinformer.go
@@ -367,7 +367,7 @@ func (k *kubeData) initInformers(client kubernetes.Interface) error {
 		return err
 	}
 
-	log.Infof("Starting kubernetes informers, waiting for syncronization")
+	log.Infof("Starting kubernetes informers, waiting for synchronization")
 	informerFactory.Start(k.stopChan)
 	informerFactory.WaitForCacheSync(k.stopChan)
 	k.serviceMap = make(map[string]string)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,7 +64,6 @@ func (m *Metrics) aggregateMetrics(connectionStatus event.ConnectionStatusAttr) 
 		flow.OutgoingBytes += connectionStatus.OutgoingBytes
 		flow.LastTstamp = connectionStatus.LastTstamp
 		flow.State = connectionStatus.State
-		// m.ConnectionFlow[connectionStatus.ConnectionID] = flow
 	} else {
 		m.ConnectionFlow[connectionStatus.ConnectionID] = &connectionStatus
 	}

--- a/pkg/policyengine/accessControl.go
+++ b/pkg/policyengine/accessControl.go
@@ -113,7 +113,6 @@ func (acl *AccessControl) RulesLookup(serviceSrc string, serviceDst string, mbgD
 			resultAction = myRule.Action
 			bitrate = myRule.Bitrate
 		}
-		// plog.Infof("Rules Matched.. action=%d", myRule.Action)
 	}
 	return priority, resultAction, bitrate
 }

--- a/pkg/util/jsonapi/client.go
+++ b/pkg/util/jsonapi/client.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -92,7 +94,7 @@ func (c *Client) do(method, path string, body []byte) (*Response, error) {
 
 // NewClient returns a new HTTP client.
 func NewClient(host string, port uint16, tlsConfig *tls.Config) *Client {
-	serverURL := fmt.Sprintf("https://%s:%d", host, port)
+	serverURL := "https://" + net.JoinHostPort(host, strconv.Itoa(int(port)))
 	return &Client{
 		client: &http.Client{
 			Transport: &http.Transport{TLSClientConfig: tlsConfig},


### PR DESCRIPTION
This PR enables additional linters. The list represents (what I think is) a reasonable set of linters that should be run in CICD.
However, some linters are currently disabled in the `golangci.yaml` configuration as the existing code does not pass the checks.

Future PRs can update the linter set or their configuration by removing the commented out lines and setting `issues.new: false` in `golangci.yaml`  and then running `make lint` and fixing any reported issues. This work will tracked in a #61.