### PR TITLE
Policy engine integration with new cp

### DIFF
--- a/cmd/gwctl/subcommand/policy.go
+++ b/cmd/gwctl/subcommand/policy.go
@@ -62,7 +62,7 @@ func (o *policyCreateOptions) run() error {
 	}
 	switch o.pType {
 	case policyengine.LbType:
-		return g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.PolicyLoadBalancer(o.policy), o.gwDest, client.Add)
+		return g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.LBScheme(o.policy), o.gwDest, client.Add)
 	case policyengine.AccessType:
 		policy, err := policyFromFile(o.policyFile)
 		if err != nil {
@@ -136,7 +136,7 @@ func (o *policyDeleteOptions) run() error {
 	}
 	switch o.pType {
 	case policyengine.LbType:
-		err = g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.PolicyLoadBalancer(o.policy), o.gwDest, client.Del)
+		err = g.SendLBPolicy(o.serviceSrc, o.serviceDst, policyengine.LBScheme(o.policy), o.gwDest, client.Del)
 	case policyengine.AccessType:
 		policy, err := policyFromFile(o.policyFile)
 		if err != nil {

--- a/cmd/gwctl/subcommand/policy.go
+++ b/cmd/gwctl/subcommand/policy.go
@@ -68,7 +68,13 @@ func (o *policyCreateOptions) run() error {
 		if err != nil {
 			return err
 		}
-		return g.SendAccessPolicy(policy, client.Add)
+		err = g.Policies.Create(policy)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Access Policy %s created successfully\n", policy.Name)
+		return nil
 
 	default:
 		return fmt.Errorf("unknown policy type")
@@ -142,7 +148,13 @@ func (o *policyDeleteOptions) run() error {
 		if err != nil {
 			return err
 		}
-		return g.SendAccessPolicy(policy, client.Del)
+		err = g.Policies.Delete(policy)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Access policy %s was deleted successfully\n", policy.Name)
+		return nil
 	default:
 		return fmt.Errorf("unknown policy type")
 	}
@@ -182,26 +194,16 @@ func (o *policyGetOptions) run() error {
 		return err
 	}
 
-	lPolicies, err := g.GetLBPolicies()
-	if err != nil {
-		return err
-	}
+	// TODO: Get Load-balancing policies
 
-	fmt.Printf("GW Load-balancing policies\n")
-	for d, val := range lPolicies {
-		for s, p := range val {
-			fmt.Printf("ServiceSrc: %v ServiceDst: %v Policy: %v\n", s, d, p)
-		}
-	}
-
-	accessPolicies, err := g.GetAccessPolicies()
+	accessPolicies, err := g.Policies.List()
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Access policies\n")
-	for d := range accessPolicies {
-		fmt.Printf("Access policy %d: %v\n", d, accessPolicies[d])
+	for d, policy := range *accessPolicies.(*[]api.Policy) {
+		fmt.Printf("Access policy %d: %s\n", d, policy.Name)
 	}
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -82,7 +82,7 @@ func (c *Client) SendAccessPolicy(policy api.Policy, command int) error {
 }
 
 // SendLBPolicy sends an LB request to the GW.
-func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine.PolicyLoadBalancer, gwDest string, command int) error {
+func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, scheme policyengine.LBScheme, gwDest string, command int) error {
 	path := policyengine.PolicyRoute + policyengine.LbRoute
 	switch command {
 	case Add:
@@ -92,7 +92,7 @@ func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine
 	default:
 		return fmt.Errorf("unknown command")
 	}
-	jsonReq, err := json.Marshal(policyengine.LoadBalancerRule{ServiceSrc: serviceSrc, ServiceDst: serviceDst, Policy: policy, DefaultMbg: gwDest})
+	jsonReq, err := json.Marshal(policyengine.LBPolicy{ServiceSrc: serviceSrc, ServiceDst: serviceDst, Scheme: scheme, DefaultMbg: gwDest})
 	if err != nil {
 		return err
 	}
@@ -101,16 +101,16 @@ func (c *Client) SendLBPolicy(serviceSrc, serviceDst string, policy policyengine
 }
 
 // GetLBPolicies sends an LB get request to the GW.
-func (c *Client) GetLBPolicies() (map[string]map[string]policyengine.PolicyLoadBalancer, error) {
-	var policies map[string]map[string]policyengine.PolicyLoadBalancer
+func (c *Client) GetLBPolicies() (map[string]map[string]policyengine.LBScheme, error) {
+	var policies map[string]map[string]policyengine.LBScheme
 	path := policyengine.PolicyRoute + policyengine.LbRoute
 	resp, err := c.client.Get(path)
 	if err != nil {
-		return make(map[string]map[string]policyengine.PolicyLoadBalancer), err
+		return make(map[string]map[string]policyengine.LBScheme), err
 	}
 
 	if err := json.Unmarshal(resp.Body, &policies); err != nil {
-		return make(map[string]map[string]policyengine.PolicyLoadBalancer), err
+		return make(map[string]map[string]policyengine.LBScheme), err
 	}
 	return policies, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/clusterlink-net/clusterlink/pkg/api"
 	event "github.com/clusterlink-net/clusterlink/pkg/controlplane/eventmanager"
 	"github.com/clusterlink-net/clusterlink/pkg/policyengine"
-	"github.com/clusterlink-net/clusterlink/pkg/policyengine/policytypes"
 	"github.com/clusterlink-net/clusterlink/pkg/util/jsonapi"
 	"github.com/clusterlink-net/clusterlink/pkg/util/rest"
 )
@@ -25,6 +24,8 @@ type Client struct {
 	Imports *rest.Client
 	// Bindings client.
 	Bindings *rest.Client
+	// Policies client.
+	Policies *rest.Client
 }
 
 // New returns a new client.
@@ -56,6 +57,12 @@ func New(host string, port uint16, tlsConfig *tls.Config) *Client {
 			SampleObject: []api.Binding{},
 			SampleList:   []api.Binding{},
 		}),
+		Policies: rest.NewClient(&rest.Config{
+			Client:       client,
+			BasePath:     "/policies",
+			SampleObject: api.Policy{},
+			SampleList:   []api.Policy{},
+		}),
 	}
 }
 
@@ -65,6 +72,7 @@ const (
 	Del
 )
 
+// TODO: delete when old controlplane is no longer active
 // SendAccessPolicy sends the policy engine a request to add, update (using add) or delete an access policy
 func (c *Client) SendAccessPolicy(policy api.Policy, command int) error {
 	path := policyengine.PolicyRoute + policyengine.AccessRoute
@@ -111,21 +119,6 @@ func (c *Client) GetLBPolicies() (map[string]map[string]policyengine.LBScheme, e
 
 	if err := json.Unmarshal(resp.Body, &policies); err != nil {
 		return make(map[string]map[string]policyengine.LBScheme), err
-	}
-	return policies, nil
-}
-
-// GetAccessPolicies returns a slice of ConnectivityPolicies, that are currently used by the connectivity PDP
-func (c *Client) GetAccessPolicies() ([]policytypes.ConnectivityPolicy, error) {
-	var policies []policytypes.ConnectivityPolicy
-	path := policyengine.PolicyRoute + policyengine.AccessRoute
-	resp, err := c.client.Get(path)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(resp.Body, &policies); err != nil {
-		return nil, err
 	}
 	return policies, nil
 }

--- a/pkg/controlplane/authz.go
+++ b/pkg/controlplane/authz.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwt"
 
 	"github.com/clusterlink-net/clusterlink/pkg/controlplane/api"
+	"github.com/clusterlink-net/clusterlink/pkg/controlplane/eventmanager"
 )
 
 const (
@@ -66,8 +67,16 @@ func (cp *Instance) AuthorizeEgress(req *EgressAuthorizationRequest) (*EgressAut
 	}
 
 	// TODO: get k8s attributes using cp.kubeClient
-	// TODO: call policy engine
-	target := bindings[0].Peer
+	connReq := eventmanager.ConnectionRequestAttr{DstService: req.Import, Direction: eventmanager.Outgoing}
+	authResp, err := cp.policyDecider.AuthorizeAndRouteConnection(&connReq)
+	if err != nil {
+		return nil, err
+	}
+	if authResp.Action != eventmanager.Allow {
+		return &EgressAuthorizationResponse{Allowed: false}, nil
+	}
+
+	target := authResp.TargetMbg
 	peer := cp.GetPeer(target)
 	if peer == nil {
 		return nil, fmt.Errorf("peer '%s' does not exist", target)
@@ -112,7 +121,15 @@ func (cp *Instance) AuthorizeIngress(req *IngressAuthorizationRequest) (*Ingress
 
 	resp.ServiceExists = true
 
-	// TODO: call policy engine
+	connReq := eventmanager.ConnectionRequestAttr{DstService: req.Service, Direction: eventmanager.Incoming}
+	authResp, err := cp.policyDecider.AuthorizeAndRouteConnection(&connReq)
+	if err != nil {
+		return nil, err
+	}
+	if authResp.Action != eventmanager.Allow {
+		resp.Allowed = false
+		return resp, nil
+	}
 	resp.Allowed = true
 
 	// create access token

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -67,7 +67,9 @@ func (cp *Instance) CreatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	return cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+	cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+
+	return nil
 }
 
 // UpdatePeer updates new route target for egress dataplane connections.
@@ -93,7 +95,9 @@ func (cp *Instance) UpdatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	return cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+	cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+
+	return nil
 }
 
 // GetPeer returns an existing peer.
@@ -120,9 +124,7 @@ func (cp *Instance) DeletePeer(name string) (*cpstore.Peer, error) {
 		return nil, err
 	}
 
-	if err := cp.policyDecider.DeletePeer(name); err != nil {
-		return nil, err
-	}
+	cp.policyDecider.DeletePeer(name)
 
 	return peer, nil
 }
@@ -208,9 +210,7 @@ func (cp *Instance) DeleteExport(name string) (*cpstore.Export, error) {
 		return export, err
 	}
 
-	if err := cp.policyDecider.DeleteExport(name); err != nil {
-		return nil, err
-	}
+	cp.policyDecider.DeleteExport(name)
 
 	return export, nil
 }
@@ -358,9 +358,7 @@ func (cp *Instance) GetBindings(imp string) []*cpstore.Binding {
 func (cp *Instance) DeleteBinding(binding *cpstore.Binding) (*cpstore.Binding, error) {
 	cp.logger.Infof("Deleting binding '%s'->'%s'.", binding.Import, binding.Peer)
 
-	if err := cp.policyDecider.DeleteBinding(&api.Binding{Spec: binding.BindingSpec}); err != nil {
-		return nil, err
-	}
+	cp.policyDecider.DeleteBinding(&api.Binding{Spec: binding.BindingSpec})
 
 	return cp.bindings.Delete(binding)
 }

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -11,7 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/clusterlink-net/clusterlink/pkg/api"
+	event "github.com/clusterlink-net/clusterlink/pkg/controlplane/eventmanager"
 	cpstore "github.com/clusterlink-net/clusterlink/pkg/controlplane/store"
+	"github.com/clusterlink-net/clusterlink/pkg/policyengine"
 	"github.com/clusterlink-net/clusterlink/pkg/store"
 	"github.com/clusterlink-net/clusterlink/pkg/util"
 )
@@ -24,13 +27,15 @@ type Instance struct {
 	exports  *cpstore.Exports
 	imports  *cpstore.Imports
 	bindings *cpstore.Bindings
+	policies *cpstore.AccessPolicies
 
 	peerLock   sync.RWMutex
 	peerClient map[string]*client
 
-	xdsManager *xdsManager
-	ports      *portManager
-	kubeClient *kubernetes.Clientset
+	xdsManager    *xdsManager
+	ports         *portManager
+	policyDecider policyengine.PolicyDecider
+	kubeClient    *kubernetes.Clientset
 
 	jwkSignKey   jwk.Key
 	jwkVerifyKey jwk.Key
@@ -62,7 +67,7 @@ func (cp *Instance) CreatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	return nil
+	return cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
 }
 
 // UpdatePeer updates new route target for egress dataplane connections.
@@ -88,7 +93,7 @@ func (cp *Instance) UpdatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	return nil
+	return cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
 }
 
 // GetPeer returns an existing peer.
@@ -115,6 +120,10 @@ func (cp *Instance) DeletePeer(name string) (*cpstore.Peer, error) {
 		return nil, err
 	}
 
+	if err := cp.policyDecider.DeletePeer(name); err != nil {
+		return nil, err
+	}
+
 	return peer, nil
 }
 
@@ -127,6 +136,15 @@ func (cp *Instance) GetAllPeers() []*cpstore.Peer {
 // CreateExport defines a new route target for ingress dataplane connections.
 func (cp *Instance) CreateExport(export *cpstore.Export) error {
 	cp.logger.Infof("Creating export '%s'.", export.Name)
+
+	resp, err := cp.policyDecider.AddExport(&api.Export{Name: export.Name, Spec: export.ExportSpec})
+	if err != nil {
+		return err
+	}
+	if resp.Action != event.AllowAll {
+		cp.logger.Warnf("Access policies deny creating export '%s'.", export.Name)
+		return nil
+	}
 
 	if cp.initialized {
 		if err := cp.exports.Create(export); err != nil {
@@ -146,7 +164,16 @@ func (cp *Instance) CreateExport(export *cpstore.Export) error {
 func (cp *Instance) UpdateExport(export *cpstore.Export) error {
 	cp.logger.Infof("Updating export '%s'.", export.Name)
 
-	err := cp.exports.Update(export.Name, func(old *cpstore.Export) *cpstore.Export {
+	resp, err := cp.policyDecider.AddExport(&api.Export{Name: export.Name, Spec: export.ExportSpec})
+	if err != nil {
+		return err
+	}
+	if resp.Action != event.AllowAll {
+		cp.logger.Warnf("Access policies deny creating export '%s'.", export.Name)
+		return nil
+	}
+
+	err = cp.exports.Update(export.Name, func(old *cpstore.Export) *cpstore.Export {
 		return export
 	})
 	if err != nil {
@@ -179,6 +206,10 @@ func (cp *Instance) DeleteExport(name string) (*cpstore.Export, error) {
 	if err := cp.xdsManager.DeleteExport(name); err != nil {
 		// practically impossible
 		return export, err
+	}
+
+	if err := cp.policyDecider.DeleteExport(name); err != nil {
+		return nil, err
 	}
 
 	return export, nil
@@ -276,6 +307,15 @@ func (cp *Instance) GetAllImports() []*cpstore.Import {
 func (cp *Instance) CreateBinding(binding *cpstore.Binding) error {
 	cp.logger.Infof("Creating binding '%s'->'%s'.", binding.Import, binding.Peer)
 
+	action, err := cp.policyDecider.AddBinding(&api.Binding{Spec: binding.BindingSpec})
+	if err != nil {
+		return err
+	}
+	if action != event.Allow {
+		cp.logger.Warnf("Access policies deny creating binding '%s'->'%s' .", binding.Import, binding.Peer)
+		return nil
+	}
+
 	if cp.initialized {
 		if err := cp.bindings.Create(binding); err != nil {
 			return err
@@ -289,7 +329,16 @@ func (cp *Instance) CreateBinding(binding *cpstore.Binding) error {
 func (cp *Instance) UpdateBinding(binding *cpstore.Binding) error {
 	cp.logger.Infof("Updating binding '%s'->'%s'.", binding.Import, binding.Peer)
 
-	err := cp.bindings.Update(binding, func(old *cpstore.Binding) *cpstore.Binding {
+	action, err := cp.policyDecider.AddBinding(&api.Binding{Spec: binding.BindingSpec})
+	if err != nil {
+		return err
+	}
+	if action != event.Allow {
+		cp.logger.Warnf("Access policies deny creating binding '%s'->'%s' .", binding.Import, binding.Peer)
+		return nil
+	}
+
+	err = cp.bindings.Update(binding, func(old *cpstore.Binding) *cpstore.Binding {
 		return binding
 	})
 	if err != nil {
@@ -308,6 +357,11 @@ func (cp *Instance) GetBindings(imp string) []*cpstore.Binding {
 // DeleteBinding removes a binding of an imported service to a remote exported service.
 func (cp *Instance) DeleteBinding(binding *cpstore.Binding) (*cpstore.Binding, error) {
 	cp.logger.Infof("Deleting binding '%s'->'%s'.", binding.Import, binding.Peer)
+
+	if err := cp.policyDecider.DeleteBinding(&api.Binding{Spec: binding.BindingSpec}); err != nil {
+		return nil, err
+	}
+
 	return cp.bindings.Delete(binding)
 }
 
@@ -315,6 +369,56 @@ func (cp *Instance) DeleteBinding(binding *cpstore.Binding) (*cpstore.Binding, e
 func (cp *Instance) GetAllBindings() []*cpstore.Binding {
 	cp.logger.Info("Listing all bindings.")
 	return cp.bindings.GetAll()
+}
+
+// CreateAccessPolicy creates an access policy to allow/deny specific connections.
+func (cp *Instance) CreateAccessPolicy(policy *cpstore.AccessPolicy) error {
+	cp.logger.Infof("Creating access policy '%s'.", policy.Spec.Blob)
+
+	if cp.initialized {
+		if err := cp.policies.Create(policy); err != nil {
+			return err
+		}
+	}
+
+	return cp.policyDecider.AddAccessPolicy(&api.Policy{Spec: policy.Spec})
+}
+
+// UpdateAccessPolicy updates an access policy to allow/deny specific connections.
+func (cp *Instance) UpdateAccessPolicy(policy *cpstore.AccessPolicy) error {
+	cp.logger.Infof("Updating access policy '%s'.", policy.Spec.Blob)
+
+	err := cp.policies.Update(policy.Name, func(old *cpstore.AccessPolicy) *cpstore.AccessPolicy {
+		return policy
+	})
+	if err != nil {
+		return err
+	}
+
+	return cp.policyDecider.AddAccessPolicy(&api.Policy{Spec: policy.Spec})
+}
+
+// DeleteAccessPolicy removes an access policy to allow/deny specific connections.
+func (cp *Instance) DeleteAccessPolicy(policy *cpstore.AccessPolicy) (*cpstore.AccessPolicy, error) {
+	cp.logger.Infof("Deleting access policy '%s'.", policy.Spec.Blob)
+
+	if err := cp.policyDecider.DeleteAccessPolicy(&api.Policy{Spec: policy.Spec}); err != nil {
+		return nil, err
+	}
+
+	return cp.policies.Delete(policy.Name)
+}
+
+// GetAccessPolicy returns an access policy with the given name.
+func (cp *Instance) GetAccessPolicy(name string) *cpstore.AccessPolicy {
+	cp.logger.Infof("Getting access policy '%s'.", name)
+	return cp.policies.Get(name)
+}
+
+// GetAllAccessPolicies returns the list of all AccessPolicies.
+func (cp *Instance) GetAllAccessPolicies() []*cpstore.AccessPolicy {
+	cp.logger.Info("Listing all access policies.")
+	return cp.policies.GetAll()
 }
 
 // GetXDSClusterManager returns the xDS cluster manager.
@@ -421,17 +525,18 @@ func NewInstance(peerTLS *util.ParsedCertData, storeManager store.Manager, kubeC
 	logger.Infof("Loaded %d bindings.", peers.Len())
 
 	cp := &Instance{
-		peerTLS:     peerTLS,
-		peerClient:  make(map[string]*client),
-		peers:       peers,
-		exports:     exports,
-		imports:     imports,
-		bindings:    bindings,
-		xdsManager:  newXDSManager(),
-		ports:       newPortManager(),
-		kubeClient:  kubeClient,
-		initialized: false,
-		logger:      logger,
+		peerTLS:       peerTLS,
+		peerClient:    make(map[string]*client),
+		peers:         peers,
+		exports:       exports,
+		imports:       imports,
+		bindings:      bindings,
+		xdsManager:    newXDSManager(),
+		ports:         newPortManager(),
+		policyDecider: policyengine.NewPolicyHandler(),
+		kubeClient:    kubeClient,
+		initialized:   false,
+		logger:        logger,
 	}
 
 	// initialize instance

--- a/pkg/controlplane/store/accesspolicies.go
+++ b/pkg/controlplane/store/accesspolicies.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/clusterlink-net/clusterlink/pkg/store"
+)
+
+// AccessPolicies is a cached persistent store of Access Policies.
+type AccessPolicies struct {
+	lock  sync.RWMutex
+	cache map[string]*AccessPolicy
+	store store.ObjectStore
+
+	logger *logrus.Entry
+}
+
+// Create an AccessPolicy.
+func (s *AccessPolicies) Create(policy *AccessPolicy) error {
+	s.logger.Infof("Creating: '%s'.", policy.Name)
+
+	if policy.Version > accessPolicyStructVersion {
+		return fmt.Errorf("incompatible access policy version %d, expected: %d",
+			policy.Version, accessPolicyStructVersion)
+	}
+
+	// persist to store
+	if err := s.store.Create(policy.Name, policy); err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store in cache
+	s.cache[policy.Name] = policy
+	return nil
+}
+
+// Update an access policy.
+func (s *AccessPolicies) Update(name string, mutator func(*AccessPolicy) *AccessPolicy) error {
+	s.logger.Infof("Updating: '%s'.", name)
+
+	// persist to store
+	var policy *AccessPolicy
+	err := s.store.Update(name, func(a any) any {
+		policy = mutator(a.(*AccessPolicy))
+		return policy
+	})
+	if err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store in cache
+	s.cache[name] = policy
+	return nil
+}
+
+// Get an access policy.
+func (s *AccessPolicies) Get(name string) *AccessPolicy {
+	s.logger.Debugf("Getting '%s'.", name)
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.cache[name]
+}
+
+// Delete an access policy.
+func (s *AccessPolicies) Delete(name string) (*AccessPolicy, error) {
+	s.logger.Infof("Deleting: '%s'.", name)
+
+	// delete from store
+	if err := s.store.Delete(name); err != nil {
+		return nil, err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// delete from cache
+	val := s.cache[name]
+	delete(s.cache, name)
+	return val, nil
+}
+
+// GetAll returns all access policies in the cache.
+func (s *AccessPolicies) GetAll() []*AccessPolicy {
+	s.logger.Debug("Getting all access policies.")
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	policies := make([]*AccessPolicy, 0, len(s.cache))
+	for _, policy := range s.cache {
+		policies = append(policies, policy)
+	}
+
+	return policies
+}
+
+// Len returns the number of cached access policies.
+func (s *AccessPolicies) Len() int {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return len(s.cache)
+}
+
+// init loads the cache with items from the backing store.
+func (s *AccessPolicies) init() error {
+	s.logger.Info("Initializing.")
+
+	// get all policies from backing store
+	policies, err := s.store.GetAll()
+	if err != nil {
+		return err
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// store all policies to the cache
+	for _, object := range policies {
+		policy := object.(*AccessPolicy)
+		s.cache[policy.Name] = policy
+	}
+
+	return nil
+}
+
+// NewAccessPolicies returns a new cached store of access policies.
+func NewAccessPolicies(manager store.Manager) (*AccessPolicies, error) {
+	logger := logrus.WithField("component", "controlplane.store.accesspolicies")
+
+	policies := &AccessPolicies{
+		cache:  make(map[string]*AccessPolicy),
+		store:  manager.GetObjectStore(accessPolicyStoreName, AccessPolicy{}),
+		logger: logger,
+	}
+
+	if err := policies.init(); err != nil {
+		return nil, err
+	}
+
+	return policies, nil
+}

--- a/pkg/controlplane/store/types.go
+++ b/pkg/controlplane/store/types.go
@@ -5,15 +5,17 @@ import (
 )
 
 const (
-	peerStoreName    = "peer"
-	exportStoreName  = "export"
-	importStoreName  = "import"
-	bindingStoreName = "binding"
+	peerStoreName         = "peer"
+	exportStoreName       = "export"
+	importStoreName       = "import"
+	bindingStoreName      = "binding"
+	accessPolicyStoreName = "accessPolicy"
 
-	bindingStructVersion = 1
-	exportStructVersion  = 1
-	importStructVersion  = 1
-	peerStructVersion    = 1
+	bindingStructVersion      = 1
+	exportStructVersion       = 1
+	importStructVersion       = 1
+	peerStructVersion         = 1
+	accessPolicyStructVersion = 1
 )
 
 // Peer represents a remote peer.
@@ -99,5 +101,25 @@ func NewBinding(binding *api.Binding) *Binding {
 	return &Binding{
 		BindingSpec: binding.Spec,
 		Version:     bindingStructVersion,
+	}
+}
+
+// AccessPolicy to allow/deny specific connections
+type AccessPolicy struct {
+	api.Policy
+	// Version of the struct when object was created.
+	Version uint32
+}
+
+// Keys return the keys identifying the policy.
+func (ap *AccessPolicy) Keys() []string {
+	return []string{ap.Name}
+}
+
+// NewAccessPolicy creates a new access policy
+func NewAccessPolicy(policy *api.Policy) *AccessPolicy {
+	return &AccessPolicy{
+		Policy:  *policy,
+		Version: accessPolicyStructVersion,
 	}
 }

--- a/pkg/controlplane/store/types.go
+++ b/pkg/controlplane/store/types.go
@@ -45,11 +45,6 @@ type Export struct {
 	Version uint32
 }
 
-// Keys return the keys identifying the export.
-func (exp *Export) Keys() []string {
-	return []string{exp.Name}
-}
-
 // NewExport creates a new export.
 func NewExport(export *api.Export) *Export {
 	return &Export{
@@ -70,11 +65,6 @@ type Import struct {
 	Port uint16
 }
 
-// Keys return the keys identifying the import.
-func (imp *Import) Keys() []string {
-	return []string{imp.Name}
-}
-
 // NewImport creates a new import.
 func NewImport(imp *api.Import) *Import {
 	return &Import{
@@ -89,11 +79,6 @@ type Binding struct {
 	api.BindingSpec
 	// Version of the struct when object was created.
 	Version uint32
-}
-
-// Keys return the keys identifying the binding.
-func (b *Binding) Keys() []string {
-	return []string{b.Import, b.Peer}
 }
 
 // NewBinding creates a new binding.

--- a/pkg/controlplane/store/types.go
+++ b/pkg/controlplane/store/types.go
@@ -111,11 +111,6 @@ type AccessPolicy struct {
 	Version uint32
 }
 
-// Keys return the keys identifying the policy.
-func (ap *AccessPolicy) Keys() []string {
-	return []string{ap.Name}
-}
-
 // NewAccessPolicy creates a new access policy
 func NewAccessPolicy(policy *api.Policy) *AccessPolicy {
 	return &AccessPolicy{

--- a/pkg/policyengine/PolicyDispatcher.go
+++ b/pkg/policyengine/PolicyDispatcher.go
@@ -48,14 +48,14 @@ type PolicyDecider interface {
 
 	AuthorizeAndRouteConnection(connReq *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error)
 
-	AddPeer(peer *api.Peer) error
-	DeletePeer(name string) error
+	AddPeer(peer *api.Peer)
+	DeletePeer(name string)
 
 	AddBinding(imp *api.Binding) (event.Action, error)
-	DeleteBinding(imp *api.Binding) error
+	DeleteBinding(imp *api.Binding)
 
 	AddExport(exp *api.Export) (event.ExposeRequestResp, error)
-	DeleteExport(name string) error
+	DeleteExport(name string)
 }
 
 type MbgState struct {
@@ -272,15 +272,13 @@ func (pH *PolicyHandler) removePeerRequest(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusOK)
 }
 
-func (pH *PolicyHandler) AddPeer(peer *api.Peer) error {
+func (pH *PolicyHandler) AddPeer(peer *api.Peer) {
 	pH.addPeer(peer.Name)
-	return nil
 }
 
-func (pH *PolicyHandler) DeletePeer(name string) error {
+func (pH *PolicyHandler) DeletePeer(name string) {
 	pH.removePeer(name)
 	pH.loadBalancer.RemoveMbgFromServiceMap(name)
-	return nil
 }
 
 func (pH *PolicyHandler) newRemoteService(w http.ResponseWriter, r *http.Request) {
@@ -320,9 +318,8 @@ func (pH *PolicyHandler) AddBinding(binding *api.Binding) (event.Action, error) 
 	return event.Allow, nil
 }
 
-func (pH *PolicyHandler) DeleteBinding(binding *api.Binding) error {
+func (pH *PolicyHandler) DeleteBinding(binding *api.Binding) {
 	pH.loadBalancer.RemoveDestService(binding.Spec.Import, binding.Spec.Peer)
-	return nil
 }
 
 func (pH *PolicyHandler) exposeRequest(w http.ResponseWriter, r *http.Request) {
@@ -347,8 +344,7 @@ func (pH *PolicyHandler) AddExport(_ *api.Export) (event.ExposeRequestResp, erro
 	return event.ExposeRequestResp{Action: event.AllowAll, TargetMbgs: pH.mbgState.mbgPeers}, nil
 }
 
-func (pH *PolicyHandler) DeleteExport(_ string) error {
-	return nil
+func (pH *PolicyHandler) DeleteExport(_ string) {
 }
 
 func (pH *PolicyHandler) getConnPoliciesReq(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/policyengine/PolicyDispatcher.go
+++ b/pkg/policyengine/PolicyDispatcher.go
@@ -5,13 +5,16 @@
 package policyengine
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 
 	"github.com/go-chi/chi"
 	"github.com/sirupsen/logrus"
 
+	"github.com/clusterlink-net/clusterlink/pkg/api"
 	event "github.com/clusterlink-net/clusterlink/pkg/controlplane/eventmanager"
 	"github.com/clusterlink-net/clusterlink/pkg/policyengine/connectivitypdp"
 	"github.com/clusterlink-net/clusterlink/pkg/policyengine/policytypes"
@@ -36,8 +39,27 @@ const (
 var plog = logrus.WithField("component", "PolicyEngine")
 var MyPolicyHandler PolicyHandler
 
+type PolicyDecider interface {
+	AddLBPolicy(lbPolicy *LBPolicy) error
+	DeleteLBPolicy(lbPolicy *LBPolicy) error
+
+	AddAccessPolicy(policy *api.Policy) error
+	DeleteAccessPolicy(policy *api.Policy) error
+
+	AuthorizeAndRouteConnection(connReq *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error)
+
+	AddPeer(peer *api.Peer) error
+	DeletePeer(name string) error
+
+	AddBinding(imp *api.Binding) (event.Action, error)
+	DeleteBinding(imp *api.Binding) error
+
+	AddExport(exp *api.Export) (event.ExposeRequestResp, error)
+	DeleteExport(name string) error
+}
+
 type MbgState struct {
-	mbgPeers *[]string
+	mbgPeers []string
 }
 
 type PolicyHandler struct {
@@ -97,21 +119,21 @@ func exists(slice []string, entry string) (int, bool) {
 }
 
 func (pH *PolicyHandler) addPeer(peerMbg string) {
-	_, exist := exists(*pH.mbgState.mbgPeers, peerMbg)
+	_, exist := exists(pH.mbgState.mbgPeers, peerMbg)
 	if exist {
 		return
 	}
-	*pH.mbgState.mbgPeers = append(*pH.mbgState.mbgPeers, peerMbg)
+	pH.mbgState.mbgPeers = append(pH.mbgState.mbgPeers, peerMbg)
 	plog.Infof("Added Peer %+v", pH.mbgState.mbgPeers)
 }
 
 func (pH *PolicyHandler) removePeer(peerMbg string) {
-	index, exist := exists(*pH.mbgState.mbgPeers, peerMbg)
+	index, exist := exists(pH.mbgState.mbgPeers, peerMbg)
 	if !exist {
 		return
 	}
-	*pH.mbgState.mbgPeers = append((*pH.mbgState.mbgPeers)[:index], (*pH.mbgState.mbgPeers)[index+1:]...)
-	plog.Infof("Removed Peer(%s, %d) %+v", peerMbg, index, *pH.mbgState.mbgPeers)
+	pH.mbgState.mbgPeers = append(pH.mbgState.mbgPeers[:index], pH.mbgState.mbgPeers[index+1:]...)
+	plog.Infof("Removed Peer(%s, %d) %+v", peerMbg, index, pH.mbgState.mbgPeers)
 }
 
 func getServiceAttrs(serviceName, peer string) policytypes.WorkloadAttrs {
@@ -130,26 +152,26 @@ func getServiceAttrsForMultiplePeers(serviceName string, peers []string) []polic
 	return res
 }
 
-func (pH *PolicyHandler) decideIncomingConnection(requestAttr *event.ConnectionRequestAttr) event.Action {
+func (pH *PolicyHandler) decideIncomingConnection(requestAttr *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error) {
 	src := getServiceAttrs(requestAttr.SrcService, requestAttr.OtherMbg)
 	dest := getServiceAttrs(requestAttr.DstService, "")
 	decisions, err := pH.connectivityPDP.Decide(src, []policytypes.WorkloadAttrs{dest})
 	if err != nil {
 		plog.Errorf("error deciding on a connection: %v", err)
-		return event.Deny
+		return event.ConnectionRequestResp{Action: event.Deny}, err
 	}
 	if decisions[0].Decision == policytypes.PolicyDecisionAllow {
-		return event.Allow
+		return event.ConnectionRequestResp{Action: event.Allow}, nil
 	}
-	return event.Deny
+	return event.ConnectionRequestResp{Action: event.Deny}, nil
 }
 
-func (pH *PolicyHandler) decideOutgoingConnection(requestAttr *event.ConnectionRequestAttr) (event.Action, string) {
+func (pH *PolicyHandler) decideOutgoingConnection(requestAttr *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error) {
 	// Get a list of MBGs for the service
 	mbgList, err := pH.loadBalancer.GetTargetMbgs(requestAttr.DstService)
 	if err != nil {
 		plog.Errorf("error getting target peers: %v", err)
-		return event.Deny, ""
+		return event.ConnectionRequestResp{Action: event.Deny}, err
 	}
 
 	src := getServiceAttrs(requestAttr.SrcService, "")
@@ -157,7 +179,7 @@ func (pH *PolicyHandler) decideOutgoingConnection(requestAttr *event.ConnectionR
 	decisions, err := pH.connectivityPDP.Decide(src, dsts)
 	if err != nil {
 		plog.Errorf("error deciding on a connection: %v", err)
-		return event.Deny, ""
+		return event.ConnectionRequestResp{Action: event.Deny}, err
 	}
 
 	allowedMbgs := []string{}
@@ -170,9 +192,9 @@ func (pH *PolicyHandler) decideOutgoingConnection(requestAttr *event.ConnectionR
 	// Perform load-balancing using the filtered mbgList
 	targetMbg, err := pH.loadBalancer.LookupWith(requestAttr.SrcService, requestAttr.DstService, allowedMbgs)
 	if err != nil {
-		return event.Deny, ""
+		return event.ConnectionRequestResp{Action: event.Deny}, err
 	}
-	return event.Allow, targetMbg
+	return event.ConnectionRequestResp{Action: event.Allow, TargetMbg: targetMbg}, nil
 }
 
 func (pH *PolicyHandler) newConnectionRequest(w http.ResponseWriter, r *http.Request) {
@@ -182,25 +204,34 @@ func (pH *PolicyHandler) newConnectionRequest(w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	plog.Infof("New connection request : %+v", requestAttr)
 
-	var action event.Action
-	var targetMbg string
-	var bitrate int
-	if requestAttr.Direction == event.Incoming {
-		action = pH.decideIncomingConnection(&requestAttr)
-	} else if requestAttr.Direction == event.Outgoing {
-		action, targetMbg = pH.decideOutgoingConnection(&requestAttr)
+	resp, err := pH.AuthorizeAndRouteConnection(&requestAttr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
-
-	plog.Infof("Response : %+v", event.ConnectionRequestResp{Action: action, TargetMbg: targetMbg, BitRate: bitrate})
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(event.ConnectionRequestResp{Action: action, TargetMbg: targetMbg, BitRate: bitrate}); err != nil {
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		plog.Errorf("Error happened in JSON encode. Err: %s", err)
 		return
 	}
+}
+
+func (pH *PolicyHandler) AuthorizeAndRouteConnection(connReq *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error) {
+	plog.Infof("New connection request : %+v", connReq)
+
+	var resp event.ConnectionRequestResp
+	var err error
+	if connReq.Direction == event.Incoming {
+		resp, err = pH.decideIncomingConnection(connReq)
+	} else if connReq.Direction == event.Outgoing {
+		resp, err = pH.decideOutgoingConnection(connReq)
+	}
+
+	plog.Infof("Response : %+v", resp)
+	return resp, err
 }
 
 func (pH *PolicyHandler) addPeerRequest(w http.ResponseWriter, r *http.Request) {
@@ -236,6 +267,17 @@ func (pH *PolicyHandler) removePeerRequest(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusOK)
 }
 
+func (pH *PolicyHandler) AddPeer(peer *api.Peer) error {
+	pH.addPeer(peer.Name)
+	return nil
+}
+
+func (pH *PolicyHandler) DeletePeer(name string) error {
+	pH.removePeer(name)
+	pH.loadBalancer.RemoveMbgFromServiceMap(name)
+	return nil
+}
+
 func (pH *PolicyHandler) newRemoteService(w http.ResponseWriter, r *http.Request) {
 	var requestAttr event.NewRemoteServiceAttr
 	err := json.NewDecoder(r.Body).Decode(&requestAttr)
@@ -268,6 +310,16 @@ func (pH *PolicyHandler) removeRemoteServiceRequest(w http.ResponseWriter, r *ht
 	w.WriteHeader(http.StatusOK)
 }
 
+func (pH *PolicyHandler) AddBinding(binding *api.Binding) (event.Action, error) {
+	pH.loadBalancer.AddToServiceMap(binding.Spec.Import, binding.Spec.Peer)
+	return event.Allow, nil
+}
+
+func (pH *PolicyHandler) DeleteBinding(binding *api.Binding) error {
+	pH.loadBalancer.RemoveDestService(binding.Spec.Import, binding.Spec.Peer)
+	return nil
+}
+
 func (pH *PolicyHandler) exposeRequest(w http.ResponseWriter, r *http.Request) {
 	var requestAttr event.ExposeRequestAttr
 	err := json.NewDecoder(r.Body).Decode(&requestAttr)
@@ -280,10 +332,18 @@ func (pH *PolicyHandler) exposeRequest(w http.ResponseWriter, r *http.Request) {
 	// Currently, request is always allowed
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(event.ExposeRequestResp{Action: event.AllowAll, TargetMbgs: *pH.mbgState.mbgPeers}); err != nil {
+	if err := json.NewEncoder(w).Encode(event.ExposeRequestResp{Action: event.AllowAll, TargetMbgs: pH.mbgState.mbgPeers}); err != nil {
 		plog.Errorf("Error happened in JSON encode. Err: %s", err)
 		return
 	}
+}
+
+func (pH *PolicyHandler) AddExport(_ *api.Export) (event.ExposeRequestResp, error) {
+	return event.ExposeRequestResp{Action: event.AllowAll, TargetMbgs: pH.mbgState.mbgPeers}, nil
+}
+
+func (pH *PolicyHandler) DeleteExport(_ string) error {
+	return nil
 }
 
 func (pH *PolicyHandler) getConnPoliciesReq(w http.ResponseWriter, _ *http.Request) {
@@ -299,31 +359,27 @@ func (pH *PolicyHandler) getConnPoliciesReq(w http.ResponseWriter, _ *http.Reque
 }
 
 func (pH *PolicyHandler) addConnPolicyReq(w http.ResponseWriter, r *http.Request) {
-	var policy policytypes.ConnectivityPolicy
-	err := json.NewDecoder(r.Body).Decode(&policy)
+	policy, err := connPolicyFromBlob(r.Body)
 	if err != nil {
-		plog.Errorf("failed decoding connectivity policy: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	err = pH.connectivityPDP.AddOrUpdatePolicy(policy)
+	err = pH.connectivityPDP.AddOrUpdatePolicy(*policy)
 	if err != nil { // policy is syntactically ok, but semantically invalid - 422 is the status to return
 		plog.Errorf("failed adding connectivity policy: %v", err)
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
 
-	plog.Infof("Added policy : %+v", policy)
+	plog.Infof("Added policy : %+v", *policy)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 }
 
 func (pH *PolicyHandler) delConnPolicyReq(w http.ResponseWriter, r *http.Request) {
-	var policy policytypes.ConnectivityPolicy
-	err := json.NewDecoder(r.Body).Decode(&policy)
+	policy, err := connPolicyFromBlob(r.Body)
 	if err != nil {
-		plog.Errorf("failed decoding connectivity policy: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -335,9 +391,45 @@ func (pH *PolicyHandler) delConnPolicyReq(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	plog.Infof("Deleted policy : %+v", policy)
+	plog.Infof("Deleted policy : %+v", *policy)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+}
+
+func connPolicyFromBlob(blob io.Reader) (*policytypes.ConnectivityPolicy, error) {
+	connPolicy := &policytypes.ConnectivityPolicy{}
+	err := json.NewDecoder(blob).Decode(connPolicy)
+	if err != nil {
+		plog.Errorf("failed decoding connectivity policy: %v", err)
+		return nil, err
+	}
+	return connPolicy, nil
+}
+
+func (pH *PolicyHandler) AddLBPolicy(lbPolicy *LBPolicy) error {
+	pH.loadBalancer.SetPolicy(lbPolicy.ServiceSrc, lbPolicy.ServiceDst, lbPolicy.Scheme, lbPolicy.DefaultMbg)
+	return nil
+}
+
+func (pH *PolicyHandler) DeleteLBPolicy(lbPolicy *LBPolicy) error {
+	pH.loadBalancer.deletePolicy(lbPolicy.ServiceSrc, lbPolicy.ServiceDst, lbPolicy.Scheme, lbPolicy.DefaultMbg)
+	return nil
+}
+
+func (pH *PolicyHandler) AddAccessPolicy(policy *api.Policy) error {
+	connPolicy, err := connPolicyFromBlob(bytes.NewReader(policy.Spec.Blob))
+	if err != nil {
+		return err
+	}
+	return pH.connectivityPDP.AddOrUpdatePolicy(*connPolicy)
+}
+
+func (pH *PolicyHandler) DeleteAccessPolicy(policy *api.Policy) error {
+	connPolicy, err := connPolicyFromBlob(bytes.NewReader(policy.Spec.Blob))
+	if err != nil {
+		return err
+	}
+	return pH.connectivityPDP.DeletePolicy(connPolicy.Name, connPolicy.Privileged)
 }
 
 func (pH *PolicyHandler) policyWelcome(w http.ResponseWriter, _ *http.Request) {
@@ -348,9 +440,7 @@ func (pH *PolicyHandler) policyWelcome(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (pH *PolicyHandler) init(router *chi.Mux) {
-	pH.mbgState.mbgPeers = &([]string{})
-	pH.loadBalancer = &LoadBalancer{}
-	pH.loadBalancer.Init()
+	pH.loadBalancer = NewLoadBalancer()
 	pH.connectivityPDP = connectivitypdp.NewPDP()
 
 	routes := pH.Routes(router)
@@ -360,4 +450,11 @@ func (pH *PolicyHandler) init(router *chi.Mux) {
 func StartPolicyDispatcher(router *chi.Mux) {
 	plog.Infof("Policy Engine started")
 	MyPolicyHandler.init(router)
+}
+
+func NewPolicyHandler() PolicyDecider {
+	return &PolicyHandler{
+		loadBalancer:    NewLoadBalancer(),
+		connectivityPDP: connectivitypdp.NewPDP(),
+	}
 }

--- a/pkg/policyengine/PolicyDispatcher_test.go
+++ b/pkg/policyengine/PolicyDispatcher_test.go
@@ -158,12 +158,12 @@ func TestOutgoingConnectionRequests(t *testing.T) {
 	require.Equal(t, event.Allow, connReqResp.Action)
 	require.Equal(t, mbg2, connReqResp.TargetMbg)
 
-	// Src service does not much the spec of the single access policy
+	// Src service does not match the spec of the single access policy
 	requestAttr = event.ConnectionRequestAttr{SrcService: badSvcName, DstService: svcName, Direction: event.Outgoing}
 	connReqResp = sendConnectionRequest(t, &requestAttr)
 	require.Equal(t, event.Deny, connReqResp.Action)
 
-	// Dst service does not much the spec of the single access policy
+	// Dst service does not match the spec of the single access policy
 	requestAttr = event.ConnectionRequestAttr{SrcService: svcName, DstService: badSvcName, Direction: event.Outgoing}
 	connReqResp = sendConnectionRequest(t, &requestAttr)
 	require.Equal(t, event.Deny, connReqResp.Action)

--- a/tests/k8s.sh
+++ b/tests/k8s.sh
@@ -50,6 +50,8 @@ function test_k8s {
   kubectl exec -i gwctl -- gwctl create peer --host cl-dataplane --port 443 --name peer1
   kubectl exec -i gwctl -- gwctl create import --name foo --host bla --port 9999
   kubectl exec -i gwctl -- gwctl create binding --import foo --peer peer1
+  kubectl cp $SCRIPT_DIR/../pkg/policyengine/policytypes/examples/allowAll.json gwctl:/tmp/allowAll.json
+  kubectl exec -i gwctl -- gwctl create policy --type access --policyFile /tmp/allowAll.json
 
   # get imported service port
   PORT=$(kubectl exec -i gwctl -- /bin/bash -c "gwctl get import --name foo | jq '.Status.Listener.Port' | tr -d '\n'")


### PR DESCRIPTION
Includes:
* API calls to CRUD access policies
* Calling policy engine to authorize outgoing/incoming connections
* Policy engine sets remote peer for outgoing connections
* Calling policy engine to authorize adding bindings and exports
* Informing policy engine of added/removed peers and removed bindings and exports
* Persistent storage of access policies

Does not include:
* Handling load-balancing policies

