### PR TITLE
.github/workflows: add timeout to e2e tests

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -27,7 +27,10 @@ jobs:
       run: make docker-build
     - name: Run e2e connectivity test on a kind cluster
       run: ./tests/k8s.sh
+      timeout-minutes: 10
     - name: Run e2e connectivity test on a kind cluster with go dataplane
       run: ./tests/k8s.sh go
+      timeout-minutes: 10
     - name: Run end-to-end tests
       run: make tests-e2e
+      timeout-minutes: 10


### PR DESCRIPTION
Adding timeout to github actions for the e2e-tests