### PR TITLE
Fix failing volume mount in "make copr-fix"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ vet-go: ; $(info vetting code...)
 	@go vet ./...
 
 copr-fix: ; $(info adding copyright header...)
-	docker run -it --rm -v $(pwd):/github/workspace apache/skywalking-eyes header fix
+	docker run -it --rm -v $(shell pwd):/github/workspace apache/skywalking-eyes header fix
 
 #------------------------------------------------------
 # Build targets


### PR DESCRIPTION
Currently, when running `make copr-fix` I get (on both Ubuntu and Windows):
```
$ make copr-fix
adding copyright header...
docker run -it --rm -v :/github/workspace apache/skywalking-eyes header fix
docker: invalid spec: :/github/workspace: empty section between colons.
See 'docker run --help'.
make: *** [Makefile:48: copr-fix] Error 125
```

Seems like `$(pwd)` is not good enough on some environments.
Many suggest to replace it with `$(shell pwd)`