### PR TITLE
cmd/cl-adm: Fix bug that disables envoy use

### DIFF
--- a/cmd/cl-adm/templates/config.go
+++ b/cmd/cl-adm/templates/config.go
@@ -91,6 +91,8 @@ func (c Config) TemplateArgs() (map[string]interface{}, error) {
 		"dataplanes":    c.Dataplanes,
 		"dataplaneType": c.DataplaneType,
 
+		"dataplaneTypeEnvoy": DataplaneTypeEnvoy,
+
 		"fabricCA":         base64.StdEncoding.EncodeToString(fabricCA),
 		"peerCA":           base64.StdEncoding.EncodeToString(peerCA),
 		"controlplaneCert": base64.StdEncoding.EncodeToString(controlplaneCert),


### PR DESCRIPTION
This PR fixes a recent bug in cl-adm which disallows the use of envoy dataplane.