### PR TITLE
.github/workflows: Remove go-dataplane e2e test

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -28,9 +28,10 @@ jobs:
     - name: Run e2e connectivity test on a kind cluster
       run: ./tests/k8s.sh
       timeout-minutes: 10
-    - name: Run e2e connectivity test on a kind cluster with go dataplane
-      run: ./tests/k8s.sh go
-      timeout-minutes: 10
+# TODO: uncomment after resolving https://github.com/clusterlink-net/clusterlink/issues/94
+#    - name: Run e2e connectivity test on a kind cluster with go dataplane
+#      run: ./tests/k8s.sh go
+#      timeout-minutes: 10
     - name: Run end-to-end tests
       run: make tests-e2e
       timeout-minutes: 10


### PR DESCRIPTION
This PR temporarily removes the go-dataplane e2e test, which currently fails due to:
https://github.com/clusterlink-net/clusterlink/issues/94