### PR TITLE
platform/k8s: Enable controller-runtime logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/clusterlink-net/clusterlink
 go 1.20
 
 require (
+	github.com/bombsimon/logrusr/v4 v4.0.0
 	github.com/envoyproxy/go-control-plane v0.11.1
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bombsimon/logrusr/v4 v4.0.0 h1:Pm0InGphX0wMhPqC02t31onlq9OVyJ98eP/Vh63t1Oo=
+github.com/bombsimon/logrusr/v4 v4.0.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=

--- a/pkg/platform/k8s/platform.go
+++ b/pkg/platform/k8s/platform.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"os"
 
+	logrusr "github.com/bombsimon/logrusr/v4"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,8 @@ func (p *Platform) GetLabelsFromIP(ip string) map[string]string {
 // NewPlatform returns a new Kubernetes platform.
 func NewPlatform() (*Platform, error) {
 	logger := logrus.WithField("component", "platform.k8s")
+	ctrl.SetLogger(logrusr.New(logrus.WithField("component", "k8s.controller-runtime")))
+
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR enables k8s controller-runtime logging.
Fixes: #140.