### PR TITLE
util/sniproxy: Reduce dial timeout

### DIFF
--- a/pkg/util/sniproxy/server.go
+++ b/pkg/util/sniproxy/server.go
@@ -15,6 +15,7 @@ package sniproxy
 
 import (
 	"net"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"inet.af/tcpproxy"
@@ -36,7 +37,9 @@ type Server struct {
 func (s *Server) Serve() error {
 	listenAddress := s.GetAddress()
 	for sni, targetAddress := range s.routes {
-		s.server.AddSNIRoute(listenAddress, sni, tcpproxy.To(targetAddress))
+		target := tcpproxy.To(targetAddress)
+		target.DialTimeout = 100 * time.Millisecond
+		s.server.AddSNIRoute(listenAddress, sni, target)
 	}
 
 	return s.server.Run()


### PR DESCRIPTION
This PR reduces the dial timeout of the SNI proxy from 10 seconds to 100ms.
Fixes: #144.