### PR TITLE
controlplane/api/authz: Change client IP header

### DIFF
--- a/cmd/cl-dataplane/app/envoyconf.go
+++ b/cmd/cl-dataplane/app/envoyconf.go
@@ -167,7 +167,6 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           stat_prefix: hcm-egress
-          skip_xff_append: true
           route_config:
             virtual_hosts:
             - name: egress
@@ -201,7 +200,7 @@ static_resources:
               allowed_headers:
                 patterns:
                 - exact: {{.importHeader}}
-                - exact: {{.ipHeader}}
+                - exact: {{.clientIPHeader}}
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/pkg/controlplane/api/authz.go
+++ b/pkg/controlplane/api/authz.go
@@ -24,7 +24,7 @@ const (
 	// ImportHeader holds the name of the imported service.
 	ImportHeader = "x-import"
 	// ClientIPHeader holds the IP address of the source client.
-	ClientIPHeader = "x-forwarded-for"
+	ClientIPHeader = "x-client-ip"
 
 	// AuthorizationHeader holds a signed token allowing ingress connections to access the dataplane.
 	AuthorizationHeader = "authorization"


### PR DESCRIPTION
This PR changes the client IP header from x-forwarded-to to x-client-ip. This is to avoid a collision with envoy ext_authz client which overrides this header.