### PR TITLE
cmd/cl-dataplane: Increasing Envoy's max_outbound_frames

### DIFF
--- a/cmd/cl-dataplane/app/envoyconf.go
+++ b/cmd/cl-dataplane/app/envoyconf.go
@@ -149,7 +149,8 @@ static_resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http2_protocol_options: {}
+          http2_protocol_options:
+            max_outbound_frames: 50000
     load_assignment:
       cluster_name: {{.egressRouterCluster}}
       endpoints:


### PR DESCRIPTION
Increasing Envoy's max_outbound_frames to support high throughput traffic.
