### PR TITLE
dataplane/server/listener: Close socket on error

### DIFF
--- a/pkg/dataplane/server/listener.go
+++ b/pkg/dataplane/server/listener.go
@@ -78,7 +78,8 @@ func (d *Dataplane) serveEgressConnections(name string, listener net.Listener) e
 		go func() {
 			err := d.initiateEgressConnection(targetPeer, accessToken, conn, tlsConfig)
 			if err != nil {
-				d.logger.Errorf("Failed to initiate egress connection:  %v.", err)
+				d.logger.Errorf("Failed to initiate egress connection: %v.", err)
+				conn.Close()
 			}
 		}()
 	}


### PR DESCRIPTION
This PR closes a failed connection socket, instead of keeping it hanging.
Fixes: #174.