### PR TITLE
cmd/cl-adm: Add container registry flag

### DIFF
--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -37,6 +37,8 @@ type PeerOptions struct {
 	DataplaneType string
 	// LogLevel is the log level.
 	LogLevel string
+	// ContainerRegistry is the container registry to pull the project images.
+	ContainerRegistry string
 }
 
 // AddFlags adds flags to fs and binds them to options.
@@ -44,8 +46,8 @@ func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
 	fs.Uint16Var(&o.Dataplanes, "dataplanes", 1, "Number of dataplanes.")
 	fs.StringVar(&o.DataplaneType, "dataplane-type", platform.DataplaneTypeEnvoy, "Type of dataplane, Supported values: \"envoy\" (default), \"go\"")
-	fs.StringVar(&o.LogLevel, "log-level", "info",
-		"The log level. One of fatal, error, warn, info, debug.")
+	fs.StringVar(&o.LogLevel, "log-level", "info", "The log level. One of fatal, error, warn, info, debug.")
+	fs.StringVar(&o.ContainerRegistry, "container-registry", "ghcr.io/clusterlink-net", "The container registry to pull the project images. If empty will use local registry.")
 }
 
 // RequiredFlags are the names of flags that must be explicitly specified.
@@ -190,6 +192,7 @@ func (o *PeerOptions) Run() error {
 		Dataplanes:              o.Dataplanes,
 		DataplaneType:           o.DataplaneType,
 		LogLevel:                o.LogLevel,
+		ContainerRegistry:       o.ContainerRegistry,
 	})
 	if err != nil {
 		return err

--- a/pkg/bootstrap/platform/config.go
+++ b/pkg/bootstrap/platform/config.go
@@ -40,6 +40,8 @@ type Config struct {
 
 	// LogLevel is the log level.
 	LogLevel string
+	// ContainerRegistry is the container registry to pull the project images.
+	ContainerRegistry string
 }
 
 const (

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -105,7 +105,7 @@ spec:
             claimName: cl-controlplane
       containers:
         - name: cl-controlplane
-          image: cl-controlplane
+          image: {{.containerRegistry}}cl-controlplane
           args: ["--log-level", "{{.logLevel}}", "--platform", "k8s"]
           imagePullPolicy: IfNotPresent
           ports:
@@ -156,7 +156,7 @@ spec:
             secretName: cl-dataplane
       containers:
         - name: dataplane
-          {{ if (eq .dataplaneType .dataplaneTypeEnvoy) }}image: cl-dataplane{{ else }}image: cl-go-dataplane{{ end }}
+          image: {{.containerRegistry}}{{ if (eq .dataplaneType .dataplaneTypeEnvoy) }}cl-dataplane{{ else }}{{.containerRegistry}}cl-go-dataplane{{ end }}
           args: ["--log-level", "{{.logLevel}}", "--controlplane-host", "cl-controlplane"]
           imagePullPolicy: IfNotPresent
           ports:
@@ -191,7 +191,7 @@ spec:
         secretName: gwctl
   containers:
     - name: gwctl
-      image: gwctl
+      image: {{.containerRegistry}}gwctl
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh"]
       args:
@@ -269,11 +269,17 @@ subjects:
 
 // K8SConfig returns a kubernetes deployment file.
 func K8SConfig(config *Config) ([]byte, error) {
+	containerRegistry := config.ContainerRegistry
+	if containerRegistry != "" {
+		containerRegistry = config.ContainerRegistry + "/"
+	}
+
 	args := map[string]interface{}{
-		"peer":          config.Peer,
-		"dataplanes":    config.Dataplanes,
-		"dataplaneType": config.DataplaneType,
-		"logLevel":      config.LogLevel,
+		"peer":              config.Peer,
+		"dataplanes":        config.Dataplanes,
+		"dataplaneType":     config.DataplaneType,
+		"logLevel":          config.LogLevel,
+		"containerRegistry": containerRegistry,
 
 		"dataplaneTypeEnvoy": DataplaneTypeEnvoy,
 

--- a/tests/e2e/k8s/util/k8s_yaml.go
+++ b/tests/e2e/k8s/util/k8s_yaml.go
@@ -64,6 +64,7 @@ func (f *Fabric) generateK8SYAML(p *peer, cfg *PeerConfig) (string, error) {
 		Dataplanes:              cfg.Dataplanes,
 		DataplaneType:           cfg.DataplaneType,
 		LogLevel:                logLevel,
+		ContainerRegistry:       "",
 	})
 
 	if err != nil {


### PR DESCRIPTION
Add a remote-image flag that chooses whether to use a local or remote image. 
Add a container-registry flag that represents the container registry to pull the project images.
Signed-off-by: Kfir Toledo <kfir.toledo@ibm.com>