### PR TITLE
controlplane: connect enable/disable peer to heartbeat

### DIFF
--- a/pkg/controlplane/authz.go
+++ b/pkg/controlplane/authz.go
@@ -174,7 +174,7 @@ func (cp *Instance) AuthorizeIngress(req *IngressAuthorizationRequest, peer stri
 // ParseAuthorizationHeader verifies an access token for an ingress dataplane connection.
 // On success, returns the parsed target cluster name.
 func (cp *Instance) ParseAuthorizationHeader(token string) (string, error) {
-	cp.logger.Info("Parsing access token.")
+	cp.logger.Debug("Parsing access token.")
 
 	parsedToken, err := jwt.ParseString(
 		token, jwt.WithVerify(jwtSignatureAlgorithm, cp.jwkVerifyKey), jwt.WithValidate(true))

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -87,6 +87,15 @@ func (cp *Instance) CreatePeer(peer *cpstore.Peer) error {
 
 	cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
 
+	client.SetPeerStatusCallback(func(isActive bool) {
+		if isActive {
+			cp.policyDecider.EnablePeer(peer.Name)
+			return
+		}
+
+		cp.policyDecider.DisablePeer(peer.Name)
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
Update peer status in policy-engine according to the heartbeat status.