### PR TITLE
tests/e2e/k8s: Allow timeout errors

### DIFF
--- a/tests/e2e/k8s/util/clusterlink.go
+++ b/tests/e2e/k8s/util/clusterlink.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"syscall"
 	"time"
@@ -64,6 +65,7 @@ func (c *ClusterLink) Cluster() *KindCluster {
 func (c *ClusterLink) WaitForControlplaneAPI() error {
 	var err error
 	for t := time.Now(); time.Since(t) < time.Second*60; time.Sleep(time.Millisecond * 100) {
+		var uerr *url.Error
 		_, err = c.client.Peers.List()
 		switch {
 		case err == nil:
@@ -73,6 +75,8 @@ func (c *ClusterLink) WaitForControlplaneAPI() error {
 		case errors.Is(err, syscall.ECONNRESET):
 			continue
 		case errors.Is(err, io.EOF):
+			continue
+		case errors.As(err, &uerr) && uerr.Timeout():
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes the function that waits for the controlplane server to come up, to allow timeout errors. This should resolve CI errors that mention: context deadline exceeded (Client.Timeout exceeded while awaiting headers).
e.g. https://github.com/clusterlink-net/clusterlink/actions/runs/6839437393/job/18597588234