### PR TITLE
Devcontainer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@
 bin/
 graphs/
 
-.dev-container
+# empty file targets
+dist/

--- a/Makefile
+++ b/Makefile
@@ -14,22 +14,29 @@ clean: ; $(info cleaning previous builds...)	@
 # Setup Targets
 #------------------------------------------------------
 
+#-- emtpy file directory (used to track build target timestamps --
+dist: ; $(info creating dist directory...)
+	@mkdir -p $@
+
 #-- development tooling --
 .PHONY: prereqs prereqs-force
 
 prereqs: ; $(info installing dev tooling...) 
-	./hack/install-devtools.sh
+	@source ./hack/install-devtools.sh
 
 prereqs-force: ; $(info force installing dev tooling...)
-	./hack/install-devtools.sh --force
+	@source ./hack/install-devtools.sh --force
 
-.dev-container: Containerfile.dev
-	docker build -f Containerfile.dev -t quay.io/$(IMAGE_ORG)/dev:latest .
-	touch $@
+.PHONY: dev-container
+dev-container: dist/.dev-container
+
+dist/.dev-container: Containerfile.dev | dist ; $(info building dev-container...)
+	@docker build -f Containerfile.dev -t quay.io/$(IMAGE_ORG)/dev:latest .
+	@touch $@
 
 .PHONY: run-dev-container
-run-dev-container: .dev-container
-	docker run --rm -it --network bridge \
+run-dev-container: dev-container ; $(info running dev-container...)
+	@docker run --rm -it --network bridge \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR):$(CURDIR) \
 		--workdir $(CURDIR) \

--- a/hack/install-devtools.sh
+++ b/hack/install-devtools.sh
@@ -14,8 +14,12 @@ if [ -z "$(which python)" ] || [ "$1" = "--force" ]; then
 	echo "please install python3 manually (https://docs.python.org/3/using/index.html)"
 fi
 
-# Go based executables are much easier
-mkdir -p "$(go env GOPATH)/bin"
+# Go based executables are much easier, just need to ensure $GOPATH/bin is available in search path ;-)
+GOBIN="$(go env GOPATH)/bin"
+mkdir -p "$GOBIN"
+if [ -z "$(echo $PATH | grep $GOBIN)" ]; then
+  export PATH="$PATH:$GOBIN"
+fi
 
 #-- kubectl
 VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)


### PR DESCRIPTION
- Ensure installed tools are added to the PATH (source instead of run tooling)
- move empty target files under `dist`
- adding missing info messages in Makefile