### PR TITLE
controlplane: Make policies deletable by name

### DIFF
--- a/cmd/gwctl/subcommand/policy.go
+++ b/cmd/gwctl/subcommand/policy.go
@@ -211,7 +211,7 @@ func (o *policyDeleteOptions) run() error {
 		if err != nil {
 			return err
 		}
-		err = g.LBPolicies.Delete(policy)
+		err = g.LBPolicies.Delete(policy.Name)
 		if err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func (o *policyDeleteOptions) run() error {
 		if err != nil {
 			return err
 		}
-		err = g.AccessPolicies.Delete(policy)
+		err = g.AccessPolicies.Delete(policy.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -466,14 +466,22 @@ func (cp *Instance) UpdateAccessPolicy(policy *cpstore.AccessPolicy) error {
 }
 
 // DeleteAccessPolicy removes an access policy to allow/deny specific connections.
-func (cp *Instance) DeleteAccessPolicy(policy *cpstore.AccessPolicy) (*cpstore.AccessPolicy, error) {
-	cp.logger.Infof("Deleting access policy '%s'.", policy.Spec.Blob)
+func (cp *Instance) DeleteAccessPolicy(name string) (*cpstore.AccessPolicy, error) {
+	cp.logger.Infof("Deleting access policy '%s'.", name)
 
-	if err := cp.policyDecider.DeleteAccessPolicy(&api.Policy{Spec: policy.Spec}); err != nil {
+	policy, err := cp.acPolicies.Delete(name)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return nil, nil
+	}
+
+	if err := cp.policyDecider.DeleteAccessPolicy(&policy.Policy); err != nil {
 		return nil, err
 	}
 
-	return cp.acPolicies.Delete(policy.Name)
+	return policy, err
 }
 
 // GetAccessPolicy returns an access policy with the given name.
@@ -516,14 +524,22 @@ func (cp *Instance) UpdateLBPolicy(policy *cpstore.LBPolicy) error {
 }
 
 // DeleteLBPolicy removes a load-balancing policy.
-func (cp *Instance) DeleteLBPolicy(policy *cpstore.LBPolicy) (*cpstore.LBPolicy, error) {
-	cp.logger.Infof("Deleting load-balancing policy '%s'.", policy.Spec.Blob)
+func (cp *Instance) DeleteLBPolicy(name string) (*cpstore.LBPolicy, error) {
+	cp.logger.Infof("Deleting load-balancing policy '%s'.", name)
 
-	if err := cp.policyDecider.DeleteLBPolicy(&api.Policy{Spec: policy.Spec}); err != nil {
+	policy, err := cp.lbPolicies.Delete(name)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return nil, nil
+	}
+
+	if err := cp.policyDecider.DeleteLBPolicy(&policy.Policy); err != nil {
 		return nil, err
 	}
 
-	return cp.lbPolicies.Delete(policy.Name)
+	return policy, nil
 }
 
 // GetLBPolicy returns a load-balancing policy with the given name.


### PR DESCRIPTION
This PR changes the API for deleting policies (both access and LB). Instead of deleting by value, delete by name.