### PR TITLE
policyengine: Don't remove bindings of a deleted peer

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -85,15 +85,15 @@ func (cp *Instance) CreatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+	cp.policyDecider.AddPeer(peer.Name)
 
 	client.SetPeerStatusCallback(func(isActive bool) {
 		if isActive {
-			cp.policyDecider.EnablePeer(peer.Name)
+			cp.policyDecider.AddPeer(peer.Name)
 			return
 		}
 
-		cp.policyDecider.DisablePeer(peer.Name)
+		cp.policyDecider.DeletePeer(peer.Name)
 	})
 
 	return nil
@@ -122,7 +122,7 @@ func (cp *Instance) UpdatePeer(peer *cpstore.Peer) error {
 		return err
 	}
 
-	cp.policyDecider.AddPeer(&api.Peer{Name: peer.Name, Spec: peer.PeerSpec})
+	cp.policyDecider.AddPeer(peer.Name)
 
 	return nil
 }

--- a/pkg/policyengine/PolicyDispatcher.go
+++ b/pkg/policyengine/PolicyDispatcher.go
@@ -187,8 +187,6 @@ func (pH *PolicyHandler) DeletePeer(name string) {
 		return
 	}
 
-	pH.loadBalancer.RemovePeerFromServiceMap(name)
-
 	delete(pH.enabledPeers, name)
 	plog.Infof("Removed Peer %s", name)
 }

--- a/pkg/policyengine/PolicyDispatcher.go
+++ b/pkg/policyengine/PolicyDispatcher.go
@@ -53,10 +53,8 @@ type PolicyDecider interface {
 
 	AuthorizeAndRouteConnection(connReq *event.ConnectionRequestAttr) (event.ConnectionRequestResp, error)
 
-	AddPeer(peer *api.Peer)
+	AddPeer(name string)
 	DeletePeer(name string)
-	DisablePeer(name string)
-	EnablePeer(name string)
 
 	AddBinding(imp *api.Binding) (event.Action, error)
 	DeleteBinding(imp *api.Binding)
@@ -173,30 +171,14 @@ func (pH *PolicyHandler) AuthorizeAndRouteConnection(connReq *event.ConnectionRe
 	return resp, err
 }
 
-func (pH *PolicyHandler) AddPeer(peer *api.Peer) {
-	if _, exists := pH.enabledPeers[peer.Name]; exists {
-		return
-	}
-
-	pH.enabledPeers[peer.Name] = true
-	plog.Infof("Added Peer %s", peer.Name)
+func (pH *PolicyHandler) AddPeer(name string) {
+	pH.enabledPeers[name] = true
+	plog.Infof("Added Peer %s", name)
 }
 
 func (pH *PolicyHandler) DeletePeer(name string) {
-	if _, exists := pH.enabledPeers[name]; !exists {
-		return
-	}
-
 	delete(pH.enabledPeers, name)
 	plog.Infof("Removed Peer %s", name)
-}
-
-func (pH *PolicyHandler) DisablePeer(name string) {
-	delete(pH.enabledPeers, name)
-}
-
-func (pH *PolicyHandler) EnablePeer(name string) {
-	pH.enabledPeers[name] = true
 }
 
 func (pH *PolicyHandler) AddBinding(binding *api.Binding) (event.Action, error) {

--- a/pkg/policyengine/PolicyDispatcher_test.go
+++ b/pkg/policyengine/PolicyDispatcher_test.go
@@ -218,22 +218,22 @@ func TestDisableEnablePeers(t *testing.T) {
 	require.Equal(t, event.Allow, connReqResp.Action)
 	require.Equal(t, peer1, connReqResp.TargetPeer) // LB policy defaults this request to be served by peer1
 
-	ph.DisablePeer(peer1)
+	ph.DeletePeer(peer1)
 
 	connReqResp, err = ph.AuthorizeAndRouteConnection(&requestAttr)
 	require.Nil(t, err)
 	require.Equal(t, event.Allow, connReqResp.Action)
 	require.Equal(t, peer2, connReqResp.TargetPeer) // peer1 is now disabled, so peer2 must be used
 
-	ph.DisablePeer(peer2)
+	ph.DeletePeer(peer2)
 
 	connReqResp, err = ph.AuthorizeAndRouteConnection(&requestAttr)
 	require.Nil(t, err)
 	require.Equal(t, event.Deny, connReqResp.Action) // no enabled peers - a Deny is returned
 	require.Equal(t, "", connReqResp.TargetPeer)
 
-	ph.EnablePeer(peer1)
-	ph.EnablePeer(peer2)
+	ph.AddPeer(peer1)
+	ph.AddPeer(peer2)
 
 	connReqResp, err = ph.AuthorizeAndRouteConnection(&requestAttr)
 	require.Nil(t, err)
@@ -242,7 +242,7 @@ func TestDisableEnablePeers(t *testing.T) {
 }
 
 func addRemoteSvc(t *testing.T, svc, peer string, ph policyengine.PolicyDecider) {
-	ph.AddPeer(&api.Peer{Name: peer}) // just in case it was not already added
+	ph.AddPeer(peer) // just in case it was not already added
 	action, err := ph.AddBinding(&api.Binding{Spec: api.BindingSpec{Import: svc, Peer: peer}})
 	require.Nil(t, err)
 	require.Equal(t, event.Allow, action)


### PR DESCRIPTION
This {R changes the policy dispatcher to avoid deletion of bindings relevant to a deleted peer.
The peer is still removed from the enabled peers list.
This allows for re-creating a deleted peer without re-creating the relevant bindings.