### PR TITLE
controlplane: Return 404 on object not found

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -141,6 +141,9 @@ func (cp *Instance) DeletePeer(name string) (*cpstore.Peer, error) {
 	if err != nil {
 		return nil, err
 	}
+	if peer == nil {
+		return nil, nil
+	}
 
 	cp.peerClient[name].StopMonitor()
 	cp.peerLock.Lock()
@@ -250,6 +253,9 @@ func (cp *Instance) DeleteExport(name string) (*cpstore.Export, error) {
 	if err != nil {
 		return nil, err
 	}
+	if export == nil {
+		return nil, nil
+	}
 
 	// Deleting k8s endpoint and service for external service.
 	exSvc := export.ExportSpec.ExternalService
@@ -343,6 +349,9 @@ func (cp *Instance) DeleteImport(name string) (*cpstore.Import, error) {
 	imp, err := cp.imports.Delete(name)
 	if err != nil {
 		return nil, err
+	}
+	if imp == nil {
+		return nil, nil
 	}
 
 	if err := cp.xdsManager.DeleteImport(name); err != nil {

--- a/pkg/controlplane/server/http/api.go
+++ b/pkg/controlplane/server/http/api.go
@@ -114,7 +114,11 @@ func peerToAPI(peer *store.Peer) *api.Peer {
 
 // Get a peer.
 func (h *peerHandler) Get(name string) (any, error) {
-	return peerToAPI(h.cp.GetPeer(name)), nil
+	peer := peerToAPI(h.cp.GetPeer(name))
+	if peer == nil {
+		return nil, nil
+	}
+	return peer, nil
 }
 
 // Delete a peer.
@@ -181,7 +185,11 @@ func exportToAPI(export *store.Export) *api.Export {
 
 // Get an export.
 func (h *exportHandler) Get(name string) (any, error) {
-	return exportToAPI(h.cp.GetExport(name)), nil
+	export := exportToAPI(h.cp.GetExport(name))
+	if export == nil {
+		return nil, nil
+	}
+	return export, nil
 }
 
 // Delete an export.
@@ -254,7 +262,11 @@ func importToAPI(imp *store.Import) *api.Import {
 
 // Get an import.
 func (h *importHandler) Get(name string) (any, error) {
-	return importToAPI(h.cp.GetImport(name)), nil
+	imp := importToAPI(h.cp.GetImport(name))
+	if imp == nil {
+		return nil, nil
+	}
+	return imp, nil
 }
 
 // Delete an import.

--- a/pkg/util/rest/server.go
+++ b/pkg/util/rest/server.go
@@ -121,7 +121,7 @@ func (s *Server) update(spec *ServerObjectSpec, w http.ResponseWriter, r *http.R
 			return
 		}
 
-		requestLogger.Errorf("Cannot create object: %v.", err)
+		requestLogger.Errorf("Cannot update object: %v.", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
This PR fixes the GET API for import/export/peer to return 404
when the requested object does not exist.
Previously, an empty 200 was returned.

This PR also fixes some wrong log message.