### PR TITLE
tests/e2e/k8s: Retry cluster creation

### DIFF
--- a/tests/e2e/k8s/util/kind.go
+++ b/tests/e2e/k8s/util/kind.go
@@ -99,11 +99,17 @@ func (c *KindCluster) IP() string {
 func (c *KindCluster) Start() {
 	c.created.Add(1)
 	c.Run(func() error {
-		// destroy cluster before creating (if exists)
-		_ = c.cluster.Destroy(context.Background())
+		// retry cluster creation up to 10 times
+		var err error
+		for i := 0; i < 10; i++ {
+			_ = c.cluster.Destroy(context.Background())
 
-		// create cluster
-		_, err := c.cluster.Create(context.Background())
+			_, err = c.cluster.Create(context.Background())
+			if err == nil {
+				break
+			}
+		}
+
 		c.created.Done()
 		if err != nil {
 			return fmt.Errorf("unable to create kind cluster: %w", err)


### PR DESCRIPTION
Kind cluster creation can fail due to a race between parallel cluster creations conflicting on API server listening port on host machine. This PR adds a retry for cluster creation to avoid these type of errors.