### PR TITLE
Set search placeholder (for en)

### DIFF
--- a/website/i18n/en.toml
+++ b/website/i18n/en.toml
@@ -1,0 +1,3 @@
+# Set the search placeholder empty instead of the default "Search this site..."
+[ui_search]
+other = " "


### PR DESCRIPTION
Replace the default search placeholder (`Search this site...`) with an empty string so only magnifying glass shows