### PR TITLE
Enable `thelper` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,7 +63,7 @@ linters:
     - tagliatelle
     - tenv
     - testableexamples
-    # - thelper
+    - thelper
     # - testpackage
     - tparallel
     - unconvert

--- a/pkg/policyengine/PolicyDispatcher_test.go
+++ b/pkg/policyengine/PolicyDispatcher_test.go
@@ -243,6 +243,7 @@ func TestDisableEnablePeers(t *testing.T) {
 
 //nolint:unparam // `svc` always receives `svcName` (allow passing other names in future)
 func addRemoteSvc(t *testing.T, svc, peer string, ph policyengine.PolicyDecider) {
+	t.Helper()
 	ph.AddPeer(peer) // just in case it was not already added
 	action, err := ph.AddBinding(&api.Binding{Spec: api.BindingSpec{Import: svc, Peer: peer}})
 	require.Nil(t, err)
@@ -254,6 +255,7 @@ func removeRemoteSvc(svc, peer string, ph policyengine.PolicyDecider) {
 }
 
 func addPolicy(t *testing.T, policy *policytypes.ConnectivityPolicy, ph policyengine.PolicyDecider) {
+	t.Helper()
 	policyBuf, err := json.Marshal(policy)
 	require.Nil(t, err)
 	apiPolicy := api.Policy{Name: policy.Name, Spec: api.PolicySpec{Blob: policyBuf}}

--- a/pkg/policyengine/loadBalancer_test.go
+++ b/pkg/policyengine/loadBalancer_test.go
@@ -44,6 +44,7 @@ func addImports(lb *policyengine.LoadBalancer) {
 
 // We repeat lookups enough times to make sure we get all the peers allowed by the relevant policy.
 func repeatLookups(t *testing.T, lb *policyengine.LoadBalancer, srcSvc, dstSvc string, peers []string) map[string]bool {
+	t.Helper()
 	res := map[string]bool{}
 	for i := 0; i < 100; i++ {
 		targetPeer, err := lb.LookupWith(srcSvc, dstSvc, peers)


### PR DESCRIPTION
- enable thelper in configuration
- call t.Helper() in helper functions so correct test case is printed