### PR TITLE
make `testpackage` linter pass

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,7 +64,7 @@ linters:
     - tenv
     - testableexamples
     # - thelper
-    # - testpackage
+    - testpackage
     - tparallel
     - unconvert
     - unparam

--- a/pkg/platform/k8s/platform.go
+++ b/pkg/platform/k8s/platform.go
@@ -114,7 +114,7 @@ func (p *Platform) DeleteService(name, host string) {
 
 // GetLabelsFromIP return all the labels for specific ip.
 func (p *Platform) GetLabelsFromIP(ip string) map[string]string {
-	return p.podReconciler.getLabelsFromIP(ip)
+	return p.podReconciler.GetLabelsFromIP(ip)
 }
 
 // NewPlatform returns a new Kubernetes platform.

--- a/tests/e2e/k8s/k8s_test.go
+++ b/tests/e2e/k8s/k8s_test.go
@@ -11,15 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package k8s_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/clusterlink-net/clusterlink/tests/e2e/k8s"
 )
 
 // TestE2EK8S runs all k8s e2e tests.
 func TestE2EK8S(t *testing.T) {
-	suite.Run(t, &TestSuite{})
+	suite.Run(t, &k8s.TestSuite{})
 }


### PR DESCRIPTION
- enable linter in configuration
- move tests to their own package
- change tests to only inspect external behavior (e.g., no labels returned for deleted Pod, not that arrays are empty)