### PR TITLE
Enable additional errcheck linter options

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -89,12 +89,8 @@ linters-settings:
 
   errcheck:
     # change some error checks which are disabled by default
-    # check-type-assertions: true
-    # check-blank: true
-    # exclude-functions:
-      # - io/ioutil.ReadFile
-      # - io.Copy(*bytes.Buffer)
-      # - io.Copy(os.Stdout)
+    check-type-assertions: true
+    check-blank: true
 
   nakedret:
     # No naked returns (default: 30)

--- a/cmd/gwctl/config/config.go
+++ b/cmd/gwctl/config/config.go
@@ -127,10 +127,13 @@ func (c *ClientConfig) GetMetricsManagerIP() string {
 /********************************/
 
 func (c *ClientConfig) createProjectfolder() (string, error) {
-	usr, _ := user.Current()
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
 	fol := path.Join(usr.HomeDir, projectFolder)
 	// Create folder
-	err := os.MkdirAll(fol, 0755)
+	err = os.MkdirAll(fol, 0755)
 	if err != nil {
 		c.logger.Errorln(err)
 		return "", err
@@ -144,7 +147,11 @@ func (c *ClientConfig) createConfigFile() error {
 		c.logger.Errorln("Client create config File", err)
 		return err
 	}
-	f := ClientPath(c.ID)
+	f, err := ClientPath(c.ID)
+	if err != nil {
+		c.logger.Errorln("Client get config file path", err)
+		return err
+	}
 	err = os.WriteFile(f, jsonC, 0600) // RW by owner only
 	c.logger.Println("Create Client config File:", f)
 	if err != nil {
@@ -156,19 +163,28 @@ func (c *ClientConfig) createConfigFile() error {
 
 // SetDefaultClient set the default Client the CLI will use.
 func (c *ClientConfig) SetDefaultClient(id string) error {
-	file := ClientPath(id)
-	link := ClientPath("")
 	// Check if the file exist
-	if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
-		c.logger.Errorf("Client config File with id %v is not exist\n", id)
+	file, err := ClientPath(id)
+	if err != nil {
+		c.logger.Errorf("failed to get client config file path for id %v\n", id)
 		return err
 	}
+	if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
+		c.logger.Errorf("Client config File with id %v does not exist\n", id)
+		return err
+	}
+
 	// Remove if the link exist
+	link, err := ClientPath("")
+	if err != nil {
+		c.logger.Errorf("failed to get client config link path\n")
+		return err
+	}
 	if _, err := os.Lstat(link); err == nil {
 		os.Remove(link)
 	}
 	// Create a link
-	err := os.Symlink(file, link)
+	err = os.Symlink(file, link)
 	if err != nil {
 		c.logger.Errorln("Error creating symlink:", err)
 		return err
@@ -177,7 +193,10 @@ func (c *ClientConfig) SetDefaultClient(id string) error {
 }
 
 func readConfigFromFile(id string) (ClientConfig, error) {
-	file := ClientPath(id)
+	file, err := ClientPath(id)
+	if err != nil {
+		return ClientConfig{}, err
+	}
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return ClientConfig{}, err
@@ -206,12 +225,15 @@ func GetClientFromID(id string) (*client.Client, error) {
 }
 
 // ClientPath get CLI config file from id.
-func ClientPath(id string) string {
+func ClientPath(id string) (string, error) {
 	cfgFile := configFile
 	if id != "" {
 		cfgFile += "_" + id
 	}
 	// set cfg file in home directory
-	usr, _ := user.Current()
-	return path.Join(usr.HomeDir, projectFolder, cfgFile)
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(usr.HomeDir, projectFolder, cfgFile), nil
 }

--- a/cmd/gwctl/subcommand/config.go
+++ b/cmd/gwctl/subcommand/config.go
@@ -63,9 +63,11 @@ func (o *currentContextOptions) run() error {
 		return err
 	}
 
-	sJSON, _ := json.MarshalIndent(s, "", " ")
-	fmt.Println("gwctl current state\n", string(sJSON))
-	return nil
+	sJSON, err := json.MarshalIndent(s, "", " ")
+	if err != nil {
+		fmt.Println("gwctl current state\n", string(sJSON))
+	}
+	return err
 }
 
 // useContext is the command line options for 'config use-context'.

--- a/pkg/controlplane/store/accesspolicies.go
+++ b/pkg/controlplane/store/accesspolicies.go
@@ -139,8 +139,9 @@ func (s *AccessPolicies) init() error {
 
 	// store all policies to the cache
 	for _, object := range policies {
-		policy := object.(*AccessPolicy)
-		s.cache[policy.Name] = policy
+		if policy, ok := object.(*AccessPolicy); ok {
+			s.cache[policy.Name] = policy
+		}
 	}
 
 	return nil

--- a/pkg/controlplane/store/bindings.go
+++ b/pkg/controlplane/store/bindings.go
@@ -186,15 +186,15 @@ func (s *Bindings) init() error {
 
 	// store all bindings to the cache
 	for _, object := range bindings {
-		binding := object.(*Binding)
+		if binding, ok := object.(*Binding); ok {
+			valMap, ok := s.cache[binding.Import]
+			if !ok {
+				valMap = make(map[string]*Binding)
+				s.cache[binding.Import] = valMap
+			}
 
-		valMap, ok := s.cache[binding.Import]
-		if !ok {
-			valMap = make(map[string]*Binding)
-			s.cache[binding.Import] = valMap
+			valMap[binding.Peer] = binding
 		}
-
-		valMap[binding.Peer] = binding
 	}
 
 	return nil

--- a/pkg/controlplane/store/exports.go
+++ b/pkg/controlplane/store/exports.go
@@ -140,8 +140,9 @@ func (s *Exports) init() error {
 
 	// store all exports to the cache
 	for _, object := range exports {
-		export := object.(*Export)
-		s.cache[export.Name] = export
+		if export, ok := object.(*Export); ok {
+			s.cache[export.Name] = export
+		}
 	}
 
 	return nil

--- a/pkg/controlplane/store/imports.go
+++ b/pkg/controlplane/store/imports.go
@@ -139,8 +139,9 @@ func (s *Imports) init() error {
 
 	// store all imports to the cache
 	for _, object := range imports {
-		imp := object.(*Import)
-		s.cache[imp.Name] = imp
+		if imp, ok := object.(*Import); ok {
+			s.cache[imp.Name] = imp
+		}
 	}
 
 	return nil

--- a/pkg/controlplane/store/lbpolicies.go
+++ b/pkg/controlplane/store/lbpolicies.go
@@ -139,8 +139,9 @@ func (s *LBPolicies) init() error {
 
 	// store all policies to the cache
 	for _, object := range policies {
-		policy := object.(*LBPolicy)
-		s.cache[policy.Name] = policy
+		if policy, ok := object.(*LBPolicy); ok {
+			s.cache[policy.Name] = policy
+		}
 	}
 
 	return nil

--- a/pkg/controlplane/store/peers.go
+++ b/pkg/controlplane/store/peers.go
@@ -139,8 +139,9 @@ func (s *Peers) init() error {
 
 	// store all peers to the cache
 	for _, object := range peers {
-		peer := object.(*Peer)
-		s.cache[peer.Name] = peer
+		if peer, ok := object.(*Peer); ok {
+			s.cache[peer.Name] = peer
+		}
 	}
 
 	return nil

--- a/pkg/k8s/kubernetes/kubeinformer.go
+++ b/pkg/k8s/kubernetes/kubeinformer.go
@@ -209,15 +209,17 @@ func (k *kubeData) getOwner(info *Info) owner {
 			log.WithError(err).WithField("key", info.Namespace+"/"+ownerReference.Name).
 				Debug("can't get ReplicaSet info from informer. Ignoring")
 		} else if ok {
-			rsInfo := item.(*metav1.ObjectMeta)
-			if len(rsInfo.OwnerReferences) > 0 {
-				return owner{
-					Name: rsInfo.OwnerReferences[0].Name,
-					Type: rsInfo.OwnerReferences[0].Kind,
+			if rsInfo, ok := item.(*metav1.ObjectMeta); ok {
+				if len(rsInfo.OwnerReferences) > 0 {
+					return owner{
+						Name: rsInfo.OwnerReferences[0].Name,
+						Type: rsInfo.OwnerReferences[0].Kind,
+					}
 				}
 			}
 		}
 	}
+
 	// If no owner references found, return itself as owner
 	return owner{
 		Name: info.Name,

--- a/pkg/policyengine/connectivitypdp/connectivity_pdp.go
+++ b/pkg/policyengine/connectivitypdp/connectivity_pdp.go
@@ -143,6 +143,7 @@ func (pt *policyTier) getPolicies() []policytypes.ConnectivityPolicy {
 func (pt *policyTier) addPolicy(policy *policytypes.ConnectivityPolicy) {
 	pt.lock.Lock()
 	defer pt.lock.Unlock()
+	//nolint:errcheck // ignore return value as we just want to make sure non exists
 	_ = pt.unsafeDeletePolicy(policy.Name) // delete an existing policy with the same name, if it exists
 	if policy.Action == policytypes.PolicyActionDeny {
 		pt.denyPolicies[policy.Name] = policy

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -32,7 +32,10 @@ const (
 func SetLog(logLevel string, logFileName string) (*os.File, error) {
 	var f *os.File
 	if logFileName != "" {
-		usr, _ := user.Current()
+		usr, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
 		logFileFullPath := path.Join(usr.HomeDir, logFileName)
 		createLogFolder(logFileFullPath)
 

--- a/pkg/versioninfo/version.go
+++ b/pkg/versioninfo/version.go
@@ -29,7 +29,7 @@ func init() {
 		case "vcs.revision":
 			Revision = kv.Value
 		case "vcs.time":
-			LastCommit, _ = time.Parse(time.RFC3339, kv.Value)
+			LastCommit, _ = time.Parse(time.RFC3339, kv.Value) //nolint:errcheck // ignore last commit not being a valid time
 		case "vcs.modified":
 			DirtyBuild = kv.Value == "true"
 		}

--- a/tests/e2e/k8s/util/kind.go
+++ b/tests/e2e/k8s/util/kind.go
@@ -102,6 +102,7 @@ func (c *KindCluster) Start() {
 		// retry cluster creation up to 10 times
 		var err error
 		for i := 0; i < 10; i++ {
+			//nolint:errcheck // ignore errors when cluster did not exist
 			_ = c.cluster.Destroy(context.Background())
 
 			_, err = c.cluster.Create(context.Background())


### PR DESCRIPTION
- enable options
- fix unchecked errors
- fix unchecked type assertions
- left some as-is (with `//nolint:errcheck` comment)