### PR TITLE
Enable `gofumpt` linter instead of `gofmt`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,8 +31,7 @@ linters:
     - ginkgolinter
     - gocritic
     - godot
-    - gofmt
-    # - gofumpt
+    - gofumpt
     - goimports
     - gomoddirectives
     - gosec

--- a/cmd/cl-adm/cmd/create/create_fabric.go
+++ b/cmd/cl-adm/cmd/create/create_fabric.go
@@ -36,13 +36,13 @@ func NewCmdCreateFabric() *cobra.Command {
 			}
 
 			// save certificate to file
-			err = os.WriteFile(config.CertificateFileName, fabricCert.RawCert(), 0600)
+			err = os.WriteFile(config.CertificateFileName, fabricCert.RawCert(), 0o600)
 			if err != nil {
 				return err
 			}
 
 			// save private key to file
-			return os.WriteFile(config.PrivateKeyFileName, fabricCert.RawKey(), 0600)
+			return os.WriteFile(config.PrivateKeyFileName, fabricCert.RawKey(), 0o600)
 		},
 	}
 }

--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -57,13 +57,13 @@ func (o *PeerOptions) RequiredFlags() []string {
 
 func (o *PeerOptions) saveCertificate(cert *bootstrap.Certificate, outDirectory string) error {
 	// save certificate to file
-	err := os.WriteFile(filepath.Join(outDirectory, config.CertificateFileName), cert.RawCert(), 0600)
+	err := os.WriteFile(filepath.Join(outDirectory, config.CertificateFileName), cert.RawCert(), 0o600)
 	if err != nil {
 		return err
 	}
 
 	// save private key to file
-	return os.WriteFile(filepath.Join(outDirectory, config.PrivateKeyFileName), cert.RawKey(), 0600)
+	return os.WriteFile(filepath.Join(outDirectory, config.PrivateKeyFileName), cert.RawKey(), 0o600)
 }
 
 func (o *PeerOptions) createControlplane(peerCert *bootstrap.Certificate) (*bootstrap.Certificate, error) {
@@ -73,7 +73,7 @@ func (o *PeerOptions) createControlplane(peerCert *bootstrap.Certificate) (*boot
 	}
 
 	outDirectory := config.ControlplaneDirectory(o.Name)
-	if err := os.Mkdir(outDirectory, 0755); err != nil {
+	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func (o *PeerOptions) createDataplane(peerCert *bootstrap.Certificate) (*bootstr
 	}
 
 	outDirectory := config.DataplaneDirectory(o.Name)
-	if err := os.Mkdir(outDirectory, 0755); err != nil {
+	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +109,7 @@ func (o *PeerOptions) createGWCTL(peerCert *bootstrap.Certificate) (*bootstrap.C
 	}
 
 	outDirectory := config.GWCTLDirectory(o.Name)
-	if err := os.Mkdir(outDirectory, 0755); err != nil {
+	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -152,7 +152,7 @@ func (o *PeerOptions) Run() error {
 	}
 
 	peerDirectory := config.PeerDirectory(o.Name)
-	if err := os.Mkdir(peerDirectory, 0755); err != nil {
+	if err := os.Mkdir(peerDirectory, 0o755); err != nil {
 		return err
 	}
 
@@ -199,7 +199,7 @@ func (o *PeerOptions) Run() error {
 	}
 
 	outPath := filepath.Join(peerDirectory, config.K8SYamlFile)
-	return os.WriteFile(outPath, k8sConfig, 0600)
+	return os.WriteFile(outPath, k8sConfig, 0o600)
 }
 
 // NewCmdCreatePeer returns a cobra.Command to run the 'create peer' subcommand.

--- a/cmd/cl-dataplane/app/server.go
+++ b/cmd/cl-dataplane/app/server.go
@@ -67,7 +67,7 @@ func (o *Options) RequiredFlags() []string {
 func (o *Options) Run() error {
 	// set log file
 	if o.LogFile != "" {
-		f, err := os.OpenFile(o.LogFile, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+		f, err := os.OpenFile(o.LogFile, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
 		if err != nil {
 			return fmt.Errorf("unable to open log file: %w", err)
 		}

--- a/cmd/cl-go-dataplane/app/server.go
+++ b/cmd/cl-go-dataplane/app/server.go
@@ -99,7 +99,7 @@ func (o *Options) runGoDataplane(peerName, dataplaneID string, parsedCertData *u
 func (o *Options) Run() error {
 	// set log file
 	if o.LogFile != "" {
-		f, err := os.OpenFile(o.LogFile, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+		f, err := os.OpenFile(o.LogFile, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
 		if err != nil {
 			return fmt.Errorf("unable to open log file: %w", err)
 		}

--- a/cmd/gwctl/config/config.go
+++ b/cmd/gwctl/config/config.go
@@ -133,7 +133,7 @@ func (c *ClientConfig) createProjectfolder() (string, error) {
 	}
 	fol := path.Join(usr.HomeDir, projectFolder)
 	// Create folder
-	err = os.MkdirAll(fol, 0755)
+	err = os.MkdirAll(fol, 0o755)
 	if err != nil {
 		c.logger.Errorln(err)
 		return "", err
@@ -152,7 +152,7 @@ func (c *ClientConfig) createConfigFile() error {
 		c.logger.Errorln("Client get config file path", err)
 		return err
 	}
-	err = os.WriteFile(f, jsonC, 0600) // RW by owner only
+	err = os.WriteFile(f, jsonC, 0o600) // RW by owner only
 	c.logger.Println("Create Client config File:", f)
 	if err != nil {
 		c.logger.Errorln("Creating client config File", err)

--- a/cmd/gwctl/subcommand/binding.go
+++ b/cmd/gwctl/subcommand/binding.go
@@ -66,7 +66,8 @@ func (o *bindingCreateOptions) run() error {
 	err = g.Bindings.Create(&api.Binding{
 		Spec: api.BindingSpec{
 			Import: o.importID,
-			Peer:   o.peer},
+			Peer:   o.peer,
+		},
 	})
 	if err != nil {
 		return err
@@ -118,7 +119,8 @@ func (o *bindingDeleteOptions) run() error {
 	err = g.Bindings.Delete(&api.Binding{
 		Spec: api.BindingSpec{
 			Import: o.importID,
-			Peer:   o.peer},
+			Peer:   o.peer,
+		},
 	})
 	if err != nil {
 		return err

--- a/cmd/gwctl/subcommand/config.go
+++ b/cmd/gwctl/subcommand/config.go
@@ -37,14 +37,12 @@ func ConfigCmd() *cobra.Command {
 }
 
 // getContextCmd is the command line options for 'config current-context'.
-type currentContextOptions struct {
-}
+type currentContextOptions struct{}
 
 // currentContextCmd - get the last gwctl context command to use.
 func currentContextCmd() *cobra.Command {
 	o := currentContextOptions{}
 	cmd := &cobra.Command{
-
 		Use:   "current-context",
 		Short: "Get gwctl current context.",
 		Long:  `Get gwctl current context.`,

--- a/cmd/gwctl/subcommand/export.go
+++ b/cmd/gwctl/subcommand/export.go
@@ -92,7 +92,8 @@ func (o *exportCreateOptions) run(isUpdate bool) error {
 		Spec: api.ExportSpec{
 			Service: api.Endpoint{
 				Host: o.host,
-				Port: o.port},
+				Port: o.port,
+			},
 			ExternalService: o.external,
 		},
 	})

--- a/cmd/gwctl/subcommand/gwctl.go
+++ b/cmd/gwctl/subcommand/gwctl.go
@@ -81,7 +81,8 @@ func (o *initOptions) run() error {
 		CertFile:       o.cert,
 		KeyFile:        o.key,
 		Dataplane:      o.dataplane,
-		PolicyEngineIP: o.policyEngineIP})
+		PolicyEngineIP: o.policyEngineIP,
+	})
 
 	return err
 }

--- a/cmd/gwctl/subcommand/import.go
+++ b/cmd/gwctl/subcommand/import.go
@@ -42,7 +42,8 @@ func ImportCreateCmd() *cobra.Command {
 		Long:  `Create an imported service that can be bounded to other peers`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(false)
-		}}
+		},
+	}
 
 	o.addFlags(cmd.Flags())
 	cmdutil.MarkFlagsRequired(cmd, []string{"name", "port"})
@@ -59,7 +60,8 @@ func ImportUpdateCmd() *cobra.Command {
 		Long:  `Update an imported service that can be bounded to other peers`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(true)
-		}}
+		},
+	}
 
 	o.addFlags(cmd.Flags())
 	cmdutil.MarkFlagsRequired(cmd, []string{"name", "port"})
@@ -92,7 +94,8 @@ func (o *importOptions) run(isUpdate bool) error {
 		Spec: api.ImportSpec{
 			Service: api.Endpoint{
 				Host: o.host,
-				Port: o.port},
+				Port: o.port,
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/controlplane/client.go
+++ b/pkg/controlplane/client.go
@@ -208,7 +208,8 @@ func newClient(peer *store.Peer, tlsConfig *tls.Config) *client {
 		stopSignal: make(chan struct{}),
 		logger: logrus.WithFields(logrus.Fields{
 			"component": "peer-client",
-			"peer":      peer}),
+			"peer":      peer,
+		}),
 	}
 
 	go c.heartbeatMonitor()

--- a/pkg/controlplane/eventmanager/events.go
+++ b/pkg/controlplane/eventmanager/events.go
@@ -64,7 +64,7 @@ type ConnectionRequestAttr struct {
 	SrcService string
 	DstService string
 	Direction  Direction
-	OtherPeer  string //Optional: Would not be set if its an outgoing connection
+	OtherPeer  string // Optional: Would not be set if its an outgoing connection
 }
 
 type ConnectionRequestResp struct {

--- a/pkg/controlplane/portmanager.go
+++ b/pkg/controlplane/portmanager.go
@@ -115,7 +115,8 @@ func newPortManager() *portManager {
 
 	logger.WithFields(logrus.Fields{
 		"start": startPort,
-		"end":   endPort},
+		"end":   endPort,
+	},
 	).Info("Initialized.")
 
 	return &portManager{

--- a/pkg/controlplane/xdsmanager.go
+++ b/pkg/controlplane/xdsmanager.go
@@ -235,7 +235,8 @@ func makeEndpointsCluster(name string, endpoints []api.Endpoint, hostname string
 }
 
 func makeTCPProxyFilter(clusterName, statPrefix string,
-	tunnelingConfig *tcpproxy.TcpProxy_TunnelingConfig) (*listener.Filter, error) {
+	tunnelingConfig *tcpproxy.TcpProxy_TunnelingConfig,
+) (*listener.Filter, error) {
 	tcpProxyConfig := &tcpproxy.TcpProxy{
 		StatPrefix: "tcp-proxy-" + statPrefix,
 		ClusterSpecifier: &tcpproxy.TcpProxy_Cluster{

--- a/pkg/dataplane/client/fetcher.go
+++ b/pkg/dataplane/client/fetcher.go
@@ -99,7 +99,8 @@ func newFetcher(ctx context.Context, conn *grpc.ClientConn, resourceType string,
 	if err != nil {
 		return nil, err
 	}
-	return &fetcher{client: client,
+	return &fetcher{
+		client:       client,
 		resourceType: resourceType,
 		dataplane:    dataplane,
 		logger:       logrus.WithField("component", "fetcher.xds.client"),

--- a/pkg/dataplane/client/xds.go
+++ b/pkg/dataplane/client/xds.go
@@ -111,10 +111,12 @@ func (x *XDSClient) Run() error {
 
 // NewXDSClient returns am xDS client which can fetch clusters and listeners from the controlplane.
 func NewXDSClient(dataplane *server.Dataplane, controlplaneTarget string, tlsConfig *tls.Config) *XDSClient {
-	return &XDSClient{dataplane: dataplane,
+	return &XDSClient{
+		dataplane:          dataplane,
 		controlplaneTarget: controlplaneTarget,
 		tlsConfig:          tlsConfig,
 		errors:             make(map[string]error),
 		logger:             logrus.WithField("component", "xds.client"),
-		clustersReady:      make(chan bool, 1)}
+		clustersReady:      make(chan bool, 1),
+	}
 }

--- a/pkg/dataplane/server/forwarder.go
+++ b/pkg/dataplane/server/forwarder.go
@@ -143,8 +143,9 @@ func (f *forwarder) run() {
 }
 
 func newForwarder(workloadConn net.Conn, peerConn net.Conn) *forwarder {
-	return &forwarder{workloadConn: workloadConn,
-		peerConn: peerConn,
-		logger:   logrus.WithField("component", "dataplane.forwarder"),
+	return &forwarder{
+		workloadConn: workloadConn,
+		peerConn:     peerConn,
+		logger:       logrus.WithField("component", "dataplane.forwarder"),
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,8 +26,10 @@ import (
 	event "github.com/clusterlink-net/clusterlink/pkg/controlplane/eventmanager"
 )
 
-var mlog = logrus.WithField("component", "Metrics")
-var MyMetricsManager Metrics
+var (
+	mlog             = logrus.WithField("component", "Metrics")
+	MyMetricsManager Metrics
+)
 
 type Metrics struct {
 	ConnectionFlow map[string]*event.ConnectionStatusAttr

--- a/pkg/platform/k8s/platform.go
+++ b/pkg/platform/k8s/platform.go
@@ -106,7 +106,8 @@ func (p *Platform) UpdateExternalService(name, host, externalName string) {
 // DeleteService deletes a service.
 func (p *Platform) DeleteService(name, host string) {
 	serviceSpec := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: host, Namespace: p.namespace}}
+		ObjectMeta: metav1.ObjectMeta{Name: host, Namespace: p.namespace},
+	}
 
 	p.logger.Infof("Deleting K8s service %s.", host)
 	go p.serviceReconciler.DeleteResource(name, serviceSpec)

--- a/pkg/platform/unknown/platform.go
+++ b/pkg/platform/unknown/platform.go
@@ -14,8 +14,7 @@
 package unknown
 
 // Platform represents an unknown platform.
-type Platform struct {
-}
+type Platform struct{}
 
 // CreateService creates a service.
 func (p *Platform) CreateService(_, _, _ string, _, _ uint16) {

--- a/pkg/policyengine/PolicyDispatcher_test.go
+++ b/pkg/policyengine/PolicyDispatcher_test.go
@@ -108,7 +108,8 @@ func TestOutgoingConnectionRequests(t *testing.T) {
 	ph := policyengine.NewPolicyHandler()
 	simpleSelector2 := metav1.LabelSelector{MatchLabels: policytypes.WorkloadAttrs{
 		policyengine.ServiceNameLabel: svcName,
-		policyengine.GatewayNameLabel: peer2}}
+		policyengine.GatewayNameLabel: peer2,
+	}}
 	simpleWorkloadSet2 := policytypes.WorkloadSetOrSelector{WorkloadSelector: &simpleSelector2}
 	policy2 := policy
 	policy2.To = []policytypes.WorkloadSetOrSelector{simpleWorkloadSet2}

--- a/pkg/policyengine/connectivitypdp/connectivity_pdp_test.go
+++ b/pkg/policyengine/connectivitypdp/connectivity_pdp_test.go
@@ -43,10 +43,12 @@ func TestPrivilegedVsRegular(t *testing.T) {
 	workloadSet := []policytypes.WorkloadSetOrSelector{trivialWorkloadSet}
 	trivialConnPol := policytypes.ConnectivityPolicy{
 		Name: "reg", Privileged: false, Action: policytypes.PolicyActionAllow,
-		From: workloadSet, To: workloadSet}
+		From: workloadSet, To: workloadSet,
+	}
 	trivialPrivConnPol := policytypes.ConnectivityPolicy{
 		Name: "priv", Privileged: true, Action: policytypes.PolicyActionDeny,
-		From: workloadSet, To: workloadSet}
+		From: workloadSet, To: workloadSet,
+	}
 
 	pdp := connectivitypdp.NewPDP()
 	dests := []policytypes.WorkloadAttrs{trivialLabel}
@@ -171,7 +173,8 @@ func TestBadSelector(t *testing.T) {
 		Name:   "aBadPolicy",
 		Action: policytypes.PolicyActionAllow,
 		From:   []policytypes.WorkloadSetOrSelector{badWorkloadSet},
-		To:     []policytypes.WorkloadSetOrSelector{trivialWorkloadSet}}
+		To:     []policytypes.WorkloadSetOrSelector{trivialWorkloadSet},
+	}
 	pdp := connectivitypdp.NewPDP()
 	err := pdp.AddOrUpdatePolicy(badSelectorPol)
 	require.NotNil(t, err)

--- a/pkg/policyengine/policytypes/connectivity_policy_test.go
+++ b/pkg/policyengine/policytypes/connectivity_policy_test.go
@@ -49,7 +49,8 @@ func TestMatching(t *testing.T) {
 func TestDecide(t *testing.T) {
 	trivialConnPol := policytypes.ConnectivityPolicy{
 		Action: policytypes.PolicyActionDeny,
-		From:   []policytypes.WorkloadSetOrSelector{trivialWorkloadSet}}
+		From:   []policytypes.WorkloadSetOrSelector{trivialWorkloadSet},
+	}
 	decision, err := trivialConnPol.Decide(trivialLabel, trivialLabel)
 	require.Nil(t, err)
 	require.Equal(t, policytypes.PolicyDecisionUndecided, decision) // no match -> no decision

--- a/pkg/store/kv/bolt/store.go
+++ b/pkg/store/kv/bolt/store.go
@@ -104,7 +104,7 @@ func (s *Store) Close() error {
 // Open a bolt store.
 func Open(path string) (*Store, error) {
 	// open
-	db, err := bbolt.Open(path, 0666, nil)
+	db, err := bbolt.Open(path, 0o666, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open store: %w", err)
 	}

--- a/pkg/util/http/server.go
+++ b/pkg/util/http/server.go
@@ -76,7 +76,8 @@ func (s *Server) GracefulStop() error {
 func NewServer(name string, tlsConfig *tls.Config) Server {
 	logger := logrus.WithFields(logrus.Fields{
 		"component": "http-server",
-		"name":      name})
+		"name":      name,
+	})
 	logWriter := logger.WriterLevel(logrus.ErrorLevel)
 
 	router := chi.NewRouter()

--- a/pkg/util/jsonapi/client.go
+++ b/pkg/util/jsonapi/client.go
@@ -130,6 +130,7 @@ func NewClient(host string, port uint16, tlsConfig *tls.Config) *Client {
 		serverURL: serverURL,
 		logger: logrus.WithFields(logrus.Fields{
 			"component":  "http-client",
-			"server-url": serverURL}),
+			"server-url": serverURL,
+		}),
 	}
 }

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -39,7 +39,7 @@ func SetLog(logLevel string, logFileName string) (*os.File, error) {
 		logFileFullPath := path.Join(usr.HomeDir, logFileName)
 		createLogFolder(logFileFullPath)
 
-		f, err := os.OpenFile(logFileFullPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+		f, err := os.OpenFile(logFileFullPath, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o600)
 		fmt.Printf("Creating log file: %v\n", logFileFullPath)
 		if err != nil {
 			return nil, fmt.Errorf("error opening log file: %w", err)
@@ -84,7 +84,7 @@ func (f *formatter) Format(entry *logrus.Entry) ([]byte, error) {
 // createLogFolder create the log folder if not exists.
 func createLogFolder(filePath string) {
 	dir := filepath.Dir(filePath)
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0o755)
 	if err != nil {
 		fmt.Println("Failed to create directory:", err)
 		return

--- a/pkg/util/rest/server.go
+++ b/pkg/util/rest/server.go
@@ -283,6 +283,7 @@ func NewServer(name string, tlsConfig *tls.Config) Server {
 		Server: utilhttp.NewServer(name, tlsConfig),
 		logger: logrus.WithFields(logrus.Fields{
 			"component": "rest-server",
-			"name":      name}),
+			"name":      name,
+		}),
 	}
 }

--- a/pkg/util/sniproxy/server.go
+++ b/pkg/util/sniproxy/server.go
@@ -59,7 +59,8 @@ func (s *Server) GracefulStop() error {
 // routes map (server name) -> (target host:port).
 func NewServer(routes map[string]string) *Server {
 	logger := logrus.WithFields(logrus.Fields{
-		"component": "sni-proxy"})
+		"component": "sni-proxy",
+	})
 
 	s := &Server{
 		Listener: tcp.NewListener("sni-proxy"),

--- a/pkg/util/tcp/listener.go
+++ b/pkg/util/tcp/listener.go
@@ -73,6 +73,7 @@ func NewListener(name string) Listener {
 		name: name,
 		logger: logrus.WithFields(logrus.Fields{
 			"component": "listener",
-			"name":      name}),
+			"name":      name,
+		}),
 	}
 }

--- a/pkg/utils/netutils/netutils.go
+++ b/pkg/utils/netutils/netutils.go
@@ -31,8 +31,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var dnsPattern = `^[a-zA-Z0-9-]{1,63}(\.[a-zA-Z0-9-]{1,63})*$`
-var dnsRegex = regexp.MustCompile(dnsPattern)
+var (
+	dnsPattern = `^[a-zA-Z0-9-]{1,63}(\.[a-zA-Z0-9-]{1,63})*$`
+	dnsRegex   = regexp.MustCompile(dnsPattern)
+)
 
 // GetConnIP returns the connection's local IP and port.
 func GetConnIP(c net.Conn) (string, string) {
@@ -106,7 +108,8 @@ func CreateDefaultResilientHTTPServer(addr string, mux http.Handler) *http.Serve
 
 // CreateResilientHTTPServer returns an http.Server configured with the timeouts provided.
 func CreateResilientHTTPServer(addr string, mux http.Handler, tlsConfig *tls.Config,
-	headerReadTimeout, writeTimeout, idleTimeout *time.Duration) *http.Server {
+	headerReadTimeout, writeTimeout, idleTimeout *time.Duration,
+) *http.Server {
 	const (
 		defaultReadHeaderTimeout = 2 * time.Second
 		defaultWriteTimeout      = 2 * time.Second

--- a/tests/e2e/k8s/suite.go
+++ b/tests/e2e/k8s/suite.go
@@ -77,7 +77,7 @@ func (s *TestSuite) SetupSuite() {
 	if err := os.RemoveAll(util.ExportedLogsPath); err != nil {
 		s.T().Fatal(fmt.Errorf("cannot cleanup logs directory: %w", err))
 	}
-	if err := os.MkdirAll(util.ExportedLogsPath, 0755); err != nil {
+	if err := os.MkdirAll(util.ExportedLogsPath, 0o755); err != nil {
 		s.T().Fatal(fmt.Errorf("cannot create logs directory: %w", err))
 	}
 

--- a/tests/e2e/k8s/util/clusterlink.go
+++ b/tests/e2e/k8s/util/clusterlink.go
@@ -123,7 +123,8 @@ func (c *ClusterLink) RestartDataplane() error {
 // Access a cluster service.
 func (c *ClusterLink) AccessService(
 	client func(*KindCluster, *Service) (string, error),
-	service *Service, allowRetry bool, expectedError error) (string, error) {
+	service *Service, allowRetry bool, expectedError error,
+) (string, error) {
 	if service.Namespace == "" {
 		service.Namespace = c.namespace
 	}

--- a/tests/e2e/k8s/util/k8s_yaml.go
+++ b/tests/e2e/k8s/util/k8s_yaml.go
@@ -66,7 +66,6 @@ func (f *Fabric) generateK8SYAML(p *peer, cfg *PeerConfig) (string, error) {
 		LogLevel:                logLevel,
 		ContainerRegistry:       "",
 	})
-
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It is a stricter version, replacing `gofmt`.
Most changes have to do with use of octal format for file permissions and placement of closing brace on structs and functions