### PR TITLE
cmd/cl-adm: Introduce `cl-secret.yaml` and `cl-instance.yaml`

### DIFF
--- a/cmd/cl-adm/config/config.go
+++ b/cmd/cl-adm/config/config.go
@@ -26,8 +26,12 @@ const (
 	DockerRunFile = "docker-run.sh"
 	// GWCTLInitFile is the filename of the gwctl-init script.
 	GWCTLInitFile = "gwctl-init.sh"
-	// K8SYamlFile is the filename of the kubernetes deployment yaml file.
-	K8SYamlFile = "k8s.yaml"
+	// K8SYAMLFile is the filename of the kubernetes deployment yaml file.
+	K8SYAMLFile = "k8s.yaml"
+	// K8SSecretYAMLFile is the filename of the kubernetes secrets yaml file.
+	K8SSecretYAMLFile = "cl-secret.yaml" //nolint:gosec // G101(Potential hardcoded credentials): Enable secret usage in filenames.
+	// K8SClusterLinkInstanceYAMLFile is the filename of the ClusterLink instance CRD file that will use by the operator.
+	K8SClusterLinkInstanceYAMLFile = "cl-instance.yaml"
 	// PersistencyDirectoryName is the directory name containing container persisted files.
 	PersistencyDirectoryName = "persist"
 


### PR DESCRIPTION
Add support to:
1. Create `cl-secret.yaml` that contains all the certificates for the controlplane and dataplane. 
2. Create `cl-instance.yaml` that use to deploy the ClusterLink project via the operator.