### PR TITLE
Makefile: don't use source command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 IMAGE_VERSION ?= latest
 IMAGE_ORG ?= clusterlink-net
 IMAGE_BASE ?= ghcr.io/$(IMAGE_ORG)
@@ -21,10 +23,10 @@ dist: ; $(info creating dist directory...)
 .PHONY: prereqs prereqs-force
 
 prereqs: ; $(info installing dev tooling...) 
-	@source ./hack/install-devtools.sh
+	@. ./hack/install-devtools.sh
 
 prereqs-force: ; $(info force installing dev tooling...)
-	@source ./hack/install-devtools.sh --force
+	@. ./hack/install-devtools.sh --force
 
 .PHONY: dev-container
 dev-container: dist/.dev-container


### PR DESCRIPTION
Before this PR, I was not able to run `make prereqs`:
```
oro@oro:~/go/src/github.com/clusterlink-net/clusterlink$ make prereqs
installing dev tooling...
make: source: No such file or directory
make: *** [Makefile:24: prereqs] Error 127
```

See here also:
https://stackoverflow.com/questions/44052093/makefile-with-source-get-error-no-such-file-or-directory