### PR TITLE
controlplane: Add CRD mode flag

### DIFF
--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -39,6 +39,9 @@ type PeerOptions struct {
 	LogLevel string
 	// ContainerRegistry is the container registry to pull the project images.
 	ContainerRegistry string
+	// CRDMode indicates whether to run a k8s CRD-based controlplane.
+	// This flag will be removed once the CRD-based controlplane feature is complete and stable.
+	CRDMode bool
 }
 
 // AddFlags adds flags to fs and binds them to options.
@@ -51,6 +54,7 @@ func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The log level. One of fatal, error, warn, info, debug.")
 	fs.StringVar(&o.ContainerRegistry, "container-registry", "ghcr.io/clusterlink-net",
 		"The container registry to pull the project images. If empty will use local registry.")
+	fs.BoolVar(&o.CRDMode, "crd-mode", false, "Run a CRD-based controlplane.")
 }
 
 // RequiredFlags are the names of flags that must be explicitly specified.
@@ -196,6 +200,7 @@ func (o *PeerOptions) Run() error {
 		DataplaneType:           o.DataplaneType,
 		LogLevel:                o.LogLevel,
 		ContainerRegistry:       o.ContainerRegistry,
+		CRDMode:                 o.CRDMode,
 	}
 	k8sConfig, err := platform.K8SConfig(platformCfg)
 	if err != nil {

--- a/cmd/cl-controlplane/app/server.go
+++ b/cmd/cl-controlplane/app/server.go
@@ -63,6 +63,9 @@ type Options struct {
 	LogFile string
 	// LogLevel is the log level.
 	LogLevel string
+	// CRDMode indicates a k8s CRD-based controlplane.
+	// This flag will be removed once the CRD-based controlplane feature is complete and stable.
+	CRDMode bool
 }
 
 // AddFlags adds flags to fs and binds them to options.
@@ -71,6 +74,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		"Path to a file where logs will be written. If not specified, logs will be printed to stderr.")
 	fs.StringVar(&o.LogLevel, "log-level", logLevel,
 		"The log level. One of fatal, error, warn, info, debug.")
+	fs.BoolVar(&o.CRDMode, "crd-mode", false, "Run a CRD-based controlplane.")
 }
 
 // Run the various controlplane servers.

--- a/pkg/bootstrap/platform/config.go
+++ b/pkg/bootstrap/platform/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	LogLevel string
 	// ContainerRegistry is the container registry to pull the project images.
 	ContainerRegistry string
+	// CRDMode indicates a CRD-based controlplane.
+	CRDMode bool
 }
 
 const (

--- a/tests/e2e/k8s/util/k8s_yaml.go
+++ b/tests/e2e/k8s/util/k8s_yaml.go
@@ -215,7 +215,7 @@ metadata:
 
 func removeControlplanePVC(yaml string) (string, error) {
 	var err error
-	search := `
+	search := `---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -226,7 +226,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
----`
+`
 	yaml, err = replaceOnce(yaml, search, "")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This PR adds a new controlplane flag for enabling the new CRD-based mode.