### PR TITLE
pkg/bootstrap: Add ingressType and namespace to config

### DIFF
--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -31,6 +31,8 @@ import (
 type PeerOptions struct {
 	// Name of the peer to create.
 	Name string
+	// Namespace where the ClusterLink components are deployed.
+	Namespace string
 	// Dataplanes is the number of dataplanes to create.
 	Dataplanes uint16
 	// DataplaneType is the type of dataplane to create (envoy or go-based)
@@ -47,6 +49,7 @@ type PeerOptions struct {
 // AddFlags adds flags to fs and binds them to options.
 func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
+	fs.StringVar(&o.Namespace, "namespace", platform.SystemNamespace, "Namespace where the ClusterLink components are deployed.")
 	fs.Uint16Var(&o.Dataplanes, "dataplanes", 1, "Number of dataplanes.")
 	fs.StringVar(&o.DataplaneType, "dataplane-type", platform.DataplaneTypeEnvoy,
 		"Type of dataplane, Supported values: \"envoy\" (default), \"go\"")
@@ -201,6 +204,7 @@ func (o *PeerOptions) Run() error {
 		LogLevel:                o.LogLevel,
 		ContainerRegistry:       o.ContainerRegistry,
 		CRDMode:                 o.CRDMode,
+		Namespace:               o.Namespace,
 	}
 	k8sConfig, err := platform.K8SConfig(platformCfg)
 	if err != nil {

--- a/pkg/bootstrap/platform/config.go
+++ b/pkg/bootstrap/platform/config.go
@@ -21,6 +21,8 @@ import (
 type Config struct {
 	// Peer is the peer name.
 	Peer string
+	// Namespace is the namespace the components deployed.
+	Namespace string
 
 	// FabricCertificate is the fabric certificate.
 	FabricCertificate *bootstrap.Certificate
@@ -42,6 +44,8 @@ type Config struct {
 	LogLevel string
 	// ContainerRegistry is the container registry to pull the project images.
 	ContainerRegistry string
+	// IngressType is the type of ingress to create.
+	IngressType string
 	// CRDMode indicates a CRD-based controlplane.
 	CRDMode bool
 }
@@ -51,4 +55,6 @@ const (
 	DataplaneTypeEnvoy = "envoy"
 	// DataplaneTypeGo represents a go-type dataplane.
 	DataplaneTypeGo = "go"
+	// SystemNamespace represents the default namespace the system use.
+	SystemNamespace = "clusterlink-system"
 )


### PR DESCRIPTION
Add Namespace to cl-adm to support replacing the namespace for ClusterLink deployment. Add Ingresstype for the operator config.