### PR TITLE
cl-controlplane: Changes to namespace env variable

### DIFF
--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/idna"
 
 	"github.com/clusterlink-net/clusterlink/cmd/cl-adm/config"
+	"github.com/clusterlink-net/clusterlink/cmd/cl-controlplane/app"
 	"github.com/clusterlink-net/clusterlink/pkg/bootstrap"
 	"github.com/clusterlink-net/clusterlink/pkg/bootstrap/platform"
 )
@@ -49,7 +50,7 @@ type PeerOptions struct {
 // AddFlags adds flags to fs and binds them to options.
 func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
-	fs.StringVar(&o.Namespace, "namespace", platform.SystemNamespace, "Namespace where the ClusterLink components are deployed.")
+	fs.StringVar(&o.Namespace, "namespace", app.SystemNamespace, "Namespace where the ClusterLink components are deployed.")
 	fs.Uint16Var(&o.Dataplanes, "dataplanes", 1, "Number of dataplanes.")
 	fs.StringVar(&o.DataplaneType, "dataplane-type", platform.DataplaneTypeEnvoy,
 		"Type of dataplane, Supported values: \"envoy\" (default), \"go\"")

--- a/cmd/cl-controlplane/app/server.go
+++ b/cmd/cl-controlplane/app/server.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -55,6 +56,12 @@ const (
 	httpServerAddress = "127.0.0.1:1100"
 	// grpcServerAddress is the address of the localhost gRPC server.
 	grpcServerAddress = "127.0.0.1:1101"
+
+	// NamespaceEnvVariable is the environment variable
+	// which should hold the clusterlink system namespace name.
+	NamespaceEnvVariable = "CL_NAMESPACE"
+	// SystemNamespace represents the default clusterlink system namespace.
+	SystemNamespace = "clusterlink-system"
 )
 
 // Options contains everything necessary to create and run a controlplane.
@@ -92,6 +99,13 @@ func (o *Options) Run() error {
 			}
 		}()
 	}
+
+	namespace := os.Getenv(NamespaceEnvVariable)
+	if namespace == "" {
+		namespace = SystemNamespace
+	}
+	logrus.Infof("ClusterLink namespace: %s", namespace)
+
 	parsedCertData, err := tls.ParseFiles(CAFile, CertificateFile, KeyFile)
 	if err != nil {
 		return err
@@ -145,7 +159,7 @@ func (o *Options) Run() error {
 
 	storeManager := kv.NewManager(kvStore)
 
-	cp, err := controlplane.NewInstance(parsedCertData, storeManager)
+	cp, err := controlplane.NewInstance(parsedCertData, storeManager, namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/bootstrap/platform/config.go
+++ b/pkg/bootstrap/platform/config.go
@@ -55,6 +55,4 @@ const (
 	DataplaneTypeEnvoy = "envoy"
 	// DataplaneTypeGo represents a go-type dataplane.
 	DataplaneTypeGo = "go"
-	// SystemNamespace represents the default namespace the system use.
-	SystemNamespace = "clusterlink-system"
 )

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -142,7 +142,7 @@ spec:
               mountPath: {{.persistencyDirectoryMountPath}}
 {{ end }}
           env:
-            - name: CL-NAMESPACE
+            - name: {{ .namespaceEnvVariable }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -326,7 +326,8 @@ func K8SConfig(config *Config) ([]byte, error) {
 		"logLevel":          config.LogLevel,
 		"containerRegistry": containerRegistry,
 
-		"dataplaneTypeEnvoy": DataplaneTypeEnvoy,
+		"dataplaneTypeEnvoy":   DataplaneTypeEnvoy,
+		"namespaceEnvVariable": cpapp.NamespaceEnvVariable,
 
 		"persistencyDirectoryMountPath": filepath.Dir(cpapp.StoreFile),
 

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -630,11 +630,11 @@ func (cp *Instance) generateJWK() error {
 }
 
 // NewInstance returns a new controlplane instance.
-func NewInstance(peerTLS *tls.ParsedCertData, storeManager store.Manager) (*Instance, error) {
+func NewInstance(peerTLS *tls.ParsedCertData, storeManager store.Manager, namespace string) (*Instance, error) {
 	logger := logrus.WithField("component", "controlplane")
 
 	// initialize platform
-	pp, err := k8s.NewPlatform()
+	pp, err := k8s.NewPlatform(namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/instance_controller.go
+++ b/pkg/operator/controller/instance_controller.go
@@ -276,7 +276,7 @@ func (r *InstanceReconciler) applyControlplane(ctx context.Context, instance *cl
 				},
 				Env: []corev1.EnvVar{
 					{
-						Name: "CL-NAMESPACE",
+						Name: cpapp.NamespaceEnvVariable,
 						ValueFrom: &corev1.EnvVarSource{
 							FieldRef: &corev1.ObjectFieldSelector{
 								FieldPath: "metadata.namespace",

--- a/pkg/platform/k8s/platform.go
+++ b/pkg/platform/k8s/platform.go
@@ -15,7 +15,6 @@ package k8s
 
 import (
 	"context"
-	"os"
 
 	logrusr "github.com/bombsimon/logrusr/v4"
 	"github.com/sirupsen/logrus"
@@ -120,7 +119,7 @@ func (p *Platform) GetLabelsFromIP(ip string) map[string]string {
 }
 
 // NewPlatform returns a new Kubernetes platform.
-func NewPlatform() (*Platform, error) {
+func NewPlatform(namespace string) (*Platform, error) {
 	logger := logrus.WithField("component", "platform.k8s")
 	ctrl.SetLogger(logrusr.New(logrus.WithField("component", "k8s.controller-runtime")))
 
@@ -151,13 +150,6 @@ func NewPlatform() (*Platform, error) {
 			logger.Error(err, "problem running manager")
 		}
 	}()
-
-	// Get namespace
-	namespace := os.Getenv("CL-NAMESPACE")
-	if namespace == "" {
-		namespace = defaultNamespace
-		logger.Logger.Infoln("the CL-NAMESPACE environment variable is not set- use default namespace")
-	}
 
 	return &Platform{
 		client:            manager.GetClient(),


### PR DESCRIPTION
This PR declares a const for the CL_NAMESPACE env variable. (Note that it was previously called CL-NAMESPACE). The env variable is read once at cmd/cl-controlplane, and propagated downwards.