### PR TITLE
cl-dataplane: Add app name constant

### DIFF
--- a/cmd/cl-dataplane/app/server.go
+++ b/cmd/cl-dataplane/app/server.go
@@ -37,6 +37,9 @@ const (
 	CertificateFile = "/etc/ssl/certs/clink-dataplane.pem"
 	// KeyFile is the path to the private-key file.
 	KeyFile = "/etc/ssl/private/clink-dataplane.pem"
+
+	// Name is the app label of dataplane pods.
+	Name = "cl-dataplane"
 )
 
 // Options contains everything necessary to create and run a dataplane.

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -153,16 +153,16 @@ metadata:
   name: cl-dataplane
   namespace: {{.namespace}}
   labels:
-    app: cl-dataplane
+    app: {{ .dataplaneAppName }}
 spec:
   replicas: {{.dataplanes}}
   selector:
     matchLabels:
-      app: cl-dataplane
+      app: {{ .dataplaneAppName }}
   template:
     metadata:
       labels:
-        app: cl-dataplane
+        app: {{ .dataplaneAppName }}
     spec:
       volumes:
         - name: ca
@@ -260,7 +260,7 @@ metadata:
   namespace: {{.namespace}}
 spec:
   selector:
-    app: cl-dataplane
+    app: {{ .dataplaneAppName }}
   ports:
     - name: dataplane
       port: {{.dataplanePort}}
@@ -328,6 +328,7 @@ func K8SConfig(config *Config) ([]byte, error) {
 
 		"dataplaneTypeEnvoy":   DataplaneTypeEnvoy,
 		"namespaceEnvVariable": cpapp.NamespaceEnvVariable,
+		"dataplaneAppName":     dpapp.Name,
 
 		"persistencyDirectoryMountPath": filepath.Dir(cpapp.StoreFile),
 

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/sirupsen/logrus"
 
+	"github.com/clusterlink-net/clusterlink/cmd/cl-dataplane/app"
 	"github.com/clusterlink-net/clusterlink/pkg/api"
 	"github.com/clusterlink-net/clusterlink/pkg/controlplane/peer"
 	cpstore "github.com/clusterlink-net/clusterlink/pkg/controlplane/store"
@@ -35,8 +36,7 @@ import (
 )
 
 const (
-	dataplaneAppName = "cl-dataplane"
-	exportPrefix     = "export_"
+	exportPrefix = "export_"
 )
 
 // Instance of a controlplane, where all API servers delegate their requested actions to.
@@ -300,7 +300,7 @@ func (cp *Instance) CreateImport(imp *cpstore.Import) error {
 
 	// TODO: handle a crash happening between storing an import and creating a service
 	if cp.initialized {
-		cp.platform.CreateService(imp.Name, imp.Service.Host, dataplaneAppName, imp.Service.Port, imp.Port)
+		cp.platform.CreateService(imp.Name, imp.Service.Host, app.Name, imp.Service.Port, imp.Port)
 	}
 
 	return nil
@@ -323,7 +323,7 @@ func (cp *Instance) UpdateImport(imp *cpstore.Import) error {
 		return err
 	}
 
-	cp.platform.UpdateService(imp.Name, imp.Service.Host, dataplaneAppName, imp.Service.Port, imp.Port)
+	cp.platform.UpdateService(imp.Name, imp.Service.Host, app.Name, imp.Service.Port, imp.Port)
 
 	return nil
 }

--- a/pkg/operator/controller/instance_controller.go
+++ b/pkg/operator/controller/instance_controller.go
@@ -489,7 +489,7 @@ func (r *InstanceReconciler) createExternalService(ctx context.Context, instance
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": "cl-dataplane",
+				"app": dpapp.Name,
 			},
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION
This PR adds an app name constant for cl-dataplane.
This constant is used by the controlplane to create imported services referencing the dataplane pods.