### PR TITLE
golangci: Change scope of godot to toplevel

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -140,3 +140,7 @@ issues:
   new: true
   # do not automatically fix (until AI assisted code improves)
   fix: false
+
+godot:
+  # Which comments to check.
+  scope: toplevel


### PR DESCRIPTION
Change the scope for godot from declarations to top-level.
- declarations - for top level declaration comments (default);
- toplevel     - for top level comments;)