### PR TITLE
controlplane/control: Support port updates

### DIFF
--- a/cmd/cl-controlplane/app/server.go
+++ b/cmd/cl-controlplane/app/server.go
@@ -175,7 +175,7 @@ func (o *Options) Run() error {
 		return fmt.Errorf("cannot create authz controllers: %w", err)
 	}
 
-	controlManager := control.NewManager(mgr.GetClient())
+	controlManager := control.NewManager(mgr.GetClient(), o.CRDMode)
 
 	xdsManager := xds.NewManager()
 	xds.RegisterService(

--- a/config/crds/clusterlink.net_imports.yaml
+++ b/config/crds/clusterlink.net_imports.yaml
@@ -60,7 +60,8 @@ spec:
                   type: object
                 type: array
               targetPort:
-                description: TargetPort of the imported service.
+                description: TargetPort of the imported service. This is the internal
+                  (non user-facing) listening port used by the dataplane pods.
                 type: integer
             required:
             - port

--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -60,6 +60,12 @@ rules:
 - apiGroups:
   - clusterlink.net
   resources:
+  - imports
+  verbs:
+  - update
+- apiGroups:
+  - clusterlink.net
+  resources:
   - instances
   verbs:
   - get

--- a/pkg/apis/clusterlink.net/v1alpha1/import.go
+++ b/pkg/apis/clusterlink.net/v1alpha1/import.go
@@ -44,6 +44,7 @@ type ImportSpec struct {
 	// Port of the imported service.
 	Port uint16 `json:"port"`
 	// TargetPort of the imported service.
+	// This is the internal (non user-facing) listening port used by the dataplane pods.
 	TargetPort uint16 `json:"targetPort,omitempty"`
 	// Sources to import from.
 	Sources []ImportSource `json:"sources"`

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -276,6 +276,11 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+{{ if .crdMode }}
+- apiGroups: ["clusterlink.net"]
+  resources: ["imports"]
+  verbs: ["update"]
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/operator/controller/instance_controller.go
+++ b/pkg/operator/controller/instance_controller.go
@@ -71,6 +71,7 @@ type InstanceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts,verbs=list;get;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list;get;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list;get;watch
+// +kubebuilder:rbac:groups=clusterlink.net,resources=imports,verbs=update
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=list;get;watch;create;update;patch;delete
 //nolint:lll // Ignore long line warning for Kubebuilder command.
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings,verbs=list;get;watch;create;update;patch;delete
@@ -455,6 +456,11 @@ func (r *InstanceReconciler) createAccessControl(ctx context.Context, name, name
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"clusterlink.net"},
+				Resources: []string{"imports"},
+				Verbs:     []string{"update"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds support for updating import target ports.
It also adds support for automatic port allocation in CRD mode.