### PR TITLE
use hugo ref for linking

### DIFF
--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -8,7 +8,6 @@ title: ClusterLink
 
 {{< /blocks/cover >}}
 
-
 {{% blocks/lead color="primary" height="auto" %}}
 
 {{% clusterlink/main %}}ClusterLink simplifies the connection between application services that are located in different domains, networks, and cloud infrastructures.{{% /clusterlink/main %}}

--- a/website/content/en/about/_index.md
+++ b/website/content/en/about/_index.md
@@ -13,12 +13,12 @@ ClusterLink is in **alpha** status and not ready for production use.
 {{% /pageinfo %}}
 ClusterLink is a secure interconnectivity solution for working across the multi-cloud. It simplifies the connection between application services that are located in different domains, networks, and cloud infrastructures.
 
-### The main usage scenarios
+## The main usage scenarios
 
 * Efficiently connecting services across multiple cloud clusters
 * Providing seamless application-centric connectivity across existing private networks
 
-### Core features
+## Core features
 
 * Ensures global presence and availability
 * Avoids vendor lock-in

--- a/website/content/en/docs/concepts/fabric.md
+++ b/website/content/en/docs/concepts/fabric.md
@@ -4,9 +4,9 @@ description: Defining a ClusterLink fabric
 weight: 32
 ---
 
-The concept of a `Fabric` encapsulates a set of cooperating [sites](/docs/concepts/sites/).
- All sites in a fabric can communicate and may share [services](/docs/concepts/services)
- between them, with access governed by [policies](/docs/concepts/policies/).
+The concept of a `Fabric` encapsulates a set of cooperating [sites]({{< ref "sites" >}}/).
+ All sites in a fabric can communicate and may share [services]({{< ref "services" >}})
+ between them, with access governed by [policies]({{< ref "policies" >}}).
  The `Fabric` acts as a root of trust for site to site communications (i.e.,
  it functions as the certificate authority enabling mutual authentication between
  sites).
@@ -43,5 +43,5 @@ This command will create the CA files `<fabric_name>.cert` and `<fabric_name>.ke
 ## Related tasks
 
 Once a `Fabric` has been created and initialized, you can proceed with configuring
- [sites](/docs/concepts/sites/). For a complete, end to end, use case please refer to the
- [iperf toturial](/docs/tutorials/iperf/).
+ [sites]({{< ref "sites" >}}). For a complete, end to end, use case please refer to the
+ [iperf toturial]({{< ref "iperf" >}}).

--- a/website/content/en/docs/concepts/sites.md
+++ b/website/content/en/docs/concepts/sites.md
@@ -5,11 +5,11 @@ weight: 34
 ---
 
 A `Site` represents a location, such as a Kubernetes cluster, participating in a
- [Fabric](/docs/concepts/fabric/). Each site may host one or more [Services](/docs/concepts/services/)
+ [Fabric]({{< ref "fabric" >}}). Each site may host one or more [Services]({{< ref "services" >}})
  it wishes to share with other sites. A site is managed by a site administrator,
  which is responsible for running the ClusterLink control and data planes. The
  administrator will typically deploy the ClusterLink components by configuring
- the [deployment CRD](/docs/getting-started/#setup). They may also wish to provide
+ the [deployment CRD]({{< ref "getting-started#setup" >}}). They may also wish to provide
  (often) coarse-grained access policies in accordance with high level corporate
  policies (e.g., "production sites should only communicate with other production sites").
 
@@ -25,7 +25,7 @@ Once a `Site` has been added to a `Fabric`, it can communicate with any other `S
 The following assume that you have access to the `clusterlink` CLI and one or more
  sites (i.e., clusters) where you'll deploy ClusterLink. The CLI can be downloaded
  from the ClusterLink [releases page on GitHub](https://github.com/clusterlink-net/clusterlink/releases/latest).
- It also assumes that you have access to the [previously created](/docs/concepts/fabric/#create-a-new-fabric-ca)
+ It also assumes that you have access to the [previously created]({{< ref "fabric#create-a-new-fabric-ca" >}})
  Fabric CA files.
 
 ### Create a new Site certificate
@@ -90,12 +90,12 @@ This operation is typically done by a local *Site administrator*, typically diff
 
     After the operator is installed, you can deploy ClusterLink by applying
     the ClusterLink instance CRD.
-    Refer to the [getting started guide](/docs/getting-started/#setup) for a description
+    Refer to the [getting started guide]({{< ref "getting-started#setup" >}}) for a description
     of the CRD instance fields.
 
 ## Related tasks
 
 Once a `Site` has been created and initialized with the ClusterLink control and data
- planes, you can proceed with configuring [services](/docs/concepts/services/)
- and [policies](/docs/concepts/policies/).
- For a complete end to end use case, refer to [iperf toturial](/docs/tutorials/iperf/).
+ planes, you can proceed with configuring [services]({{< ref "services" >}})
+ and [policies]({{< ref "policies" >}}).
+ For a complete end to end use case, refer to [iperf toturial]({{< ref "iperf" >}}).

--- a/website/content/en/docs/doc-contribution/_index.md
+++ b/website/content/en/docs/doc-contribution/_index.md
@@ -58,7 +58,7 @@ If you want to run your own local Hugo server to preview your changes as you wor
 
 <!-- TODO should add a dedicated getting-started for website authoring -->
 
-1. Follow the instructions in [Getting started](/docs/getting-started) to install Hugo
+1. Follow the instructions in [Getting started]({{< ref "getting-started" >}}) to install Hugo
  and any other tools you need. You'll need at least **Hugo version 0.110** (we recommend
  using the most recent available version), and it must be the **extended** version,
  which supports SCSS.

--- a/website/content/en/docs/getting-started/_index.md
+++ b/website/content/en/docs/getting-started/_index.md
@@ -98,4 +98,4 @@ To deploy ClusterLink on another cluster, please repeat steps 2-4 in the console
 
 ## Try it out
 
-Check out the [ClusterLink Tutorials](../../docs/tutorials/) for setting up multi-cluster connectivity for applications using two or more clusters.
+Check out the [ClusterLink Tutorials]({{< ref "tutorials" >}}) for setting up multi-cluster connectivity for applications using two or more clusters.

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -45,5 +45,6 @@ The distributed control plane and the fine grained connection establishment cont
 
 ## Where should I go next?
 
-* [Getting Started](/docs/getting-started/): Get started with ClusterLink
-* [Tutorials](/docs/tutorials/): Check out some examples and step-by-step instructions for different use cases.
+* [Getting Started]({{< ref "getting-started" >}}): Get started with ClusterLink
+* [Tutorials]({{< ref "tutorials" >}}): Check out some examples and step-by-step
+  instructions for different use cases.


### PR DESCRIPTION
Use `{{< ref "page_name#anchor_name" >}}` syntax instead of URL or file system paths for site internal links.