### PR TITLE
cl-dataplane: Disable controlplane TLS session keys

### DIFF
--- a/cmd/cl-dataplane/app/envoyconf.go
+++ b/cmd/cl-dataplane/app/envoyconf.go
@@ -92,6 +92,7 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: {{.controlplaneGRPCSNI}}
+        max_session_keys: 0 # TODO: remove once controlplane no longer uses inet.af/tcpproxy
         common_tls_context:
           tls_certificate_sds_secret_configs:
           - name: {{.certificateSecret}}
@@ -120,6 +121,7 @@ static_resources:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         sni: {{.peerName}}
+        max_session_keys: 0 # TODO: remove once controlplane no longer uses inet.af/tcpproxy
         common_tls_context:
           tls_certificate_sds_secret_configs:
           - name: {{.certificateSecret}}


### PR DESCRIPTION
This PR disables envoy from using TLS session keys when connecting to the controlplane.
Enabling session keys produces big TLS client hello packets, which cause a "buffer full" error on the controlplane's SNI proxy.