### PR TITLE
Support including files and expanding commands

### DIFF
--- a/website/content/en/docs/concepts/data/peer_crd.md
+++ b/website/content/en/docs/concepts/data/peer_crd.md
@@ -1,0 +1,19 @@
+type Peer struct {
+  metav1.TypeMeta  
+  metav1.ObjectMeta // Peer name must match the Subject name presented in its certificate
+
+  Spec   PeerSpec
+  Status PeerStatus
+}
+
+type PeerSpec struct {
+  Gateways []string // one or more gateway addresses, each in the form "host:port"
+  Attributes map[string]string // Peer's attribute set
+  // TODO: should we have fixed/required set of attributes explicitly called out and
+  // an optional attribute set encoded as a map?)
+}
+ 
+type PeerStatus struct {
+  ObservedGeneration int64
+  Conditions[] metav1.Condition
+}

--- a/website/content/en/docs/concepts/sites.md
+++ b/website/content/en/docs/concepts/sites.md
@@ -16,12 +16,15 @@ A `Site` represents a location, such as a Kubernetes cluster, participating in a
 Once a `Site` has been added to a `Fabric`, it can communicate with any other `Site`
  belonging to it. All configuration relating to service sharing (e.g., the exporting
  and importing of Services, and the setting of fine grained application policies) can be
- done with lowered privileges (e.g., by users, such as application owners).
+ done with lowered privileges (e.g., by users, such as application owners). Remote sites are
+ represented by the `Peer` Custom Resource Definition (CRD). Each `Peer` CRD instance
+ defines a remote cluster and the network endpoints of its ClusterLink gateways.
 
 ## Initializing a new Site
 
 {{< notice warning >}}
-Creating a new Site is a **Fabric** administrator level operation and should be appropriately protected.
+Creating a new Site is a **Fabric administrator** level operation and should be appropriately
+ protected.
 {{< /notice >}}
 
 ### Prerequisites
@@ -57,7 +60,7 @@ You will need the CA certificate (but **not** the CA private key) and the site c
  site administrator.
 {{< /notice >}}
 
-### Deploy ClusterLink to a Site
+## Deploy ClusterLink to a new Site
 
 {{< notice info >}}
 This operation is typically done by a local *Site administrator*, usually different
@@ -68,40 +71,72 @@ Before proceeding, ensure that the CA certificate (the CA private key is not nee
  and the site certificate and key files which were created in the previous step are
  in the current working directory.
 
-1. Install the ClusterLink deployment operator.
+### Install the ClusterLink deployment operator
 
-    ```sh
-    clusterlink site init
-    ```
+Install the ClusterLink operator by running the following command
 
-    The command assumes that kubectl is set to the correct context and credentials
-    and that the certificates were created in the local folder. If they were not,
-    add `-f <path>` to set the correct path to the certificate files.
+```sh
+clusterlink site init
+```
 
-    This command will deploy the ClusterLink deployment CRDs using the current
-    `kubectl` context. The operation requires cluster administrator privileges
-    in order to install CRDs into the cluster.
-    The ClusterLink operator is installed to the `clusterlink-operator` namespace
-    and the CA and site certificate and key are set as Kubernetes secrets
-    in the namespace. You can confirm the successful completion of the step using
-    the following commands (TODO: describe output):
+The command assumes that kubectl is set to the correct context and credentials
+and that the certificates were created in the local folder. If they were not,
+add `-f <path>` to set the correct path to the certificate files.
 
-    ```sh
-    kubectl get crds
-    ```
+This command will deploy the ClusterLink deployment CRDs using the current
+`kubectl` context. The operation requires cluster administrator privileges
+in order to install CRDs into the cluster.
+The ClusterLink operator is installed to the `clusterlink-operator` namespace
+and the CA and site certificate and key are set as Kubernetes secrets
+in the namespace. You can confirm the successful completion of the step using
+the following commands:
 
-    and
+ {{% expand summary="kubectl get crds" open="true" %}}
 
-    ```sh
-    kubectl get secret --namespace clusterlink-operator
-    ```
+ ```sh
+ output of `kubectl get crds` command
+ ```
 
-1. Deploy ClusterLink CRD instance.
+ {{% /expand %}}
 
-    After the operator is installed, you can deploy ClusterLink by applying
-    the ClusterLink instance CRD.
-    Refer to the [getting started guide]({{< ref "getting-started#setup" >}}) for a description
-    of the CRD instance fields.
+ {{% expand "_kubectl get secret --namespace clusterlink-operator_" %}}
+
+ ```sh
+ output of kubectl get secret --namespace clusterlink-operator
+ ```
+
+ {{% /expand %}}
+
+#### Deploy ClusterLink CRD instance
+
+After the operator is installed, you can deploy ClusterLink by applying
+the ClusterLink instance CRD.
+Refer to the [getting started guide]({{< ref "getting-started#setup" >}}) for a description
+of the CRD instance fields.
+
+<!-- TODO expand the sample CRD file? -->
+
+## Add or remove Sites
+
+{{< notice info >}}
+This operation is typically done by a local *Site administrator*, usually different
+ than the *Fabric administrator*.
+{{< /notice >}}
+
+Peers are added to the ClusterLink namespace by the site administrator. Information
+ regarding peer gateways and attributes is communicated out of band and not in scope
+ for this design. Not having any gateways is an error but other than that there is
+ no actual state for a Peer and the object can be reconciled immediately. Besides the
+ recommended reconciliation condition types, a Peer should also support a
+ `Reachable` (or `Seen`) condition indicating whether the peer is currently reachable,
+ and the last time it successfully responded to heartbeats.
+
+Peer names are unique and must align with the Subject name present in their certificate
+ during connection establishment. The name is used by importers in referencing an export.
+
+{{% expand summary="example CRD" %}}
+{{< readfile file="data/peer_crd.md" code="true" lang="go" >}}
+{{% /expand %}}
 
 ## Related tasks
 

--- a/website/layouts/shortcodes/expand.html
+++ b/website/layouts/shortcodes/expand.html
@@ -1,0 +1,20 @@
+<!--
+<details>
+    <summary>{{ (.Get 0) | markdownify | safeHTML}}</summary>
+    {{ .Inner | markdownify | safeHTML }}
+</details>
+-->
+
+{{- $summary := "" }}
+{{- $open := false }}
+{{- if .IsNamedParams }}
+  {{- $summary = .Get "summary" }}
+  {{- with .Get "open" }}{{ $open = . }}{{ end }}
+{{- else }}
+  {{- $summary = .Get 0 }}
+  {{- with .Get 1 }}{{ $open = . }}{{ end }}
+{{- end }}
+<details {{ if $open }}open{{ end }}>
+  <summary>{{ $summary | markdownify }}</summary>
+  {{ .Inner | markdownify }}
+</details>

--- a/website/layouts/shortcodes/readfile.html
+++ b/website/layouts/shortcodes/readfile.html
@@ -1,0 +1,41 @@
+{{/* Store ordinal, to be retrieved by parent element */}}
+{{ if ge hugo.Version "0.93.0" }}
+  {{ .Page.Store.Add "Ordinal" 1 }}
+{{ end }}
+
+{{/* Handle the "file" named parameter or a single unnamed parameter as the file
+path */}}
+{{ if .IsNamedParams }}
+	{{ $.Scratch.Set "fparameter" ( .Get "file" ) }}
+{{ else }}
+	{{ $.Scratch.Set "fparameter" ( .Get 0 ) }}
+{{ end }}
+
+
+{{/* If the first character is "/", the path is absolute from the site's
+`baseURL`. Otherwise, construct an absolute path using the current directory */}}
+
+{{ if eq (.Scratch.Get "fparameter" | printf "%.1s") "/" }}
+  {{ $.Scratch.Set "filepath" ($.Scratch.Get "fparameter") }}
+{{ else }}
+  {{ $.Scratch.Set "filepath" "/" }}
+  {{ $.Scratch.Add "filepath" $.Page.File.Dir }}
+  {{ $.Scratch.Add "filepath" ($.Scratch.Get "fparameter") }}
+{{ end }}
+
+
+{{/* If the file exists, read it and highlight it if it's code.
+Throw a compile error or print an error on the page if the file is not found */}}
+
+{{ if fileExists ($.Scratch.Get "filepath") }}
+  {{ if eq (.Get "code") "true" }}
+    {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape |
+    safeHTML ) (.Get "lang") "" -}}
+  {{ else }}
+    {{- $.Scratch.Get "filepath" | os.ReadFile -}}
+  {{ end }}
+{{ else if eq (.Get "draft") "true" }}
+
+  <p style="color: #D74848"><b><i>The file <code>{{ $.Scratch.Get "filepath" }}</code> was not found.</i></b></p> 
+
+{{ else }}{{- errorf "Shortcode %q: file %q not found at %s" .Name ($.Scratch.Get "filepath") .Position -}}{{ end }}


### PR DESCRIPTION
work in progress

add shortcodes and sample usage
- `{{% expand summary="some text" open="true|false" %}}`
- override docsy `{{% readfile "path" %}}` shortcode to not render content as HTML by default (*must* be called with `%`!)
- sites.md uses `expand` and includes `concepts/data/peer_crd.md` using `readfile` in the inner section