### PR TITLE
.github/workflows: Add write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
     - name: checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Update the permission to write packages and content for the Release GitHub action.