### PR TITLE
cl-adm: add version flag to CLI

### DIFF
--- a/cmd/cl-adm/cmd/create/create_peer.go
+++ b/cmd/cl-adm/cmd/create/create_peer.go
@@ -42,6 +42,8 @@ type PeerOptions struct {
 	LogLevel string
 	// ContainerRegistry is the container registry to pull the project images.
 	ContainerRegistry string
+	// Tag represents the tag of the project images.
+	Tag string
 	// CRDMode indicates whether to run a k8s CRD-based controlplane.
 	// This flag will be removed once the CRD-based controlplane feature is complete and stable.
 	CRDMode bool
@@ -58,6 +60,7 @@ func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The log level. One of fatal, error, warn, info, debug.")
 	fs.StringVar(&o.ContainerRegistry, "container-registry", config.DefaultRegistry,
 		"The container registry to pull the project images. If empty will use local registry.")
+	fs.StringVar(&o.Tag, "tag", "latest", "The tag of the project images.")
 	fs.BoolVar(&o.CRDMode, "crd-mode", false, "Run a CRD-based controlplane.")
 }
 
@@ -206,6 +209,7 @@ func (o *PeerOptions) Run() error {
 		ContainerRegistry:       o.ContainerRegistry,
 		CRDMode:                 o.CRDMode,
 		Namespace:               o.Namespace,
+		Tag:                     o.Tag,
 	}
 	k8sConfig, err := platform.K8SConfig(platformCfg)
 	if err != nil {

--- a/config/crds/clusterlink.net_instances.yaml
+++ b/config/crds/clusterlink.net_instances.yaml
@@ -59,11 +59,6 @@ spec:
                     - go
                     type: string
                 type: object
-              imageTag:
-                default: latest
-                description: ImageTag represents the version of the ClusterLink project
-                  images.
-                type: string
               ingress:
                 description: IngressSpec defines the type of the ingress component
                   in ClusterLink.
@@ -100,6 +95,10 @@ spec:
                 default: clusterlink-system
                 description: Namespace represents the namespace where the ClusterLink
                   project components are deployed.
+                type: string
+              tag:
+                default: latest
+                description: Tag represents the tag of the ClusterLink project images.
                 type: string
             type: object
           status:

--- a/design-proposals/project-deploymnet.md
+++ b/design-proposals/project-deploymnet.md
@@ -121,7 +121,7 @@ The ClusterLink CRD includes the following fields:
     ||Port| Port represents the port number of the external service |443 for all types,except for NodePort, where the port number will be allocated by Kubernetes | 
     |logLevel| |Log level severity for all the components (controlplane and dataplane)| "info"|
     |containerRegistry| |The container registry to pull the project images when the images is not present locally | ghcr.io/clusterlink-net|
-    |imageTag| |The project images version | latest|
+    |tag| |The project images tag | latest|
     |Namespace| | The namespace where the components of the ClusterLink project are deployed | clusterlink-system|
 
 * **Status:**

--- a/pkg/apis/clusterlink.net/v1alpha1/instance_types.go
+++ b/pkg/apis/clusterlink.net/v1alpha1/instance_types.go
@@ -118,8 +118,8 @@ type InstanceSpec struct {
 	// ContainerRegistry is the container registry to pull the ClusterLink project images.
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
 	// +kubebuilder:default="latest"
-	// ImageTag represents the version of the ClusterLink project images.
-	ImageTag string `json:"imageTag,omitempty"`
+	// Tag represents the tag of the ClusterLink project images.
+	Tag string `json:"tag,omitempty"`
 	// +kubebuilder:default="clusterlink-system"
 	// Namespace represents the namespace where the ClusterLink project components are deployed.
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/bootstrap/platform/config.go
+++ b/pkg/bootstrap/platform/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	LogLevel string
 	// ContainerRegistry is the container registry to pull the project images.
 	ContainerRegistry string
+	// Tag represents the tag of the project images.
+	Tag string
 	// IngressType is the type of ingress to create.
 	IngressType string
 	// IngressPort is the ingress port number to create.

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -120,7 +120,7 @@ spec:
 {{ end }}
       containers:
         - name: cl-controlplane
-          image: {{.containerRegistry}}cl-controlplane
+          image: {{.containerRegistry}}cl-controlplane:{{.tag}}
           args: ["--log-level", "{{.logLevel}}"{{if .crdMode }}, "--crd-mode"{{ end }}]
           imagePullPolicy: IfNotPresent
           ports:
@@ -176,7 +176,7 @@ spec:
         - name: dataplane
           image: {{.containerRegistry}}{{ 
           if (eq .dataplaneType .dataplaneTypeEnvoy) }}cl-dataplane{{ 
-          else }}cl-go-dataplane{{ end }}
+          else }}cl-go-dataplane{{ end }}:{{.tag}}
           args: ["--log-level", "{{.logLevel}}", "--controlplane-host", "cl-controlplane"]
           imagePullPolicy: IfNotPresent
           ports:
@@ -213,7 +213,7 @@ spec:
         secretName: gwctl
   containers:
     - name: gwctl
-      image: {{.containerRegistry}}gwctl
+      image: {{.containerRegistry}}gwctl:{{.tag}}
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh"]
       args:
@@ -323,6 +323,7 @@ spec:
   logLevel: {{.logLevel}}
   containerRegistry: {{.containerRegistry}}
   namespace: {{.namespace}}
+  tag: {{.tag}}
 `
 )
 
@@ -340,6 +341,7 @@ func K8SConfig(config *Config) ([]byte, error) {
 		"dataplaneType":     config.DataplaneType,
 		"logLevel":          config.LogLevel,
 		"containerRegistry": containerRegistry,
+		"tag":               config.Tag,
 
 		"dataplaneTypeEnvoy":   DataplaneTypeEnvoy,
 		"namespaceEnvVariable": cpapp.NamespaceEnvVariable,
@@ -415,6 +417,7 @@ func K8SClusterLinkInstanceConfig(config *Config, name string) ([]byte, error) {
 		"containerRegistry": containerRegistry,
 		"namespace":         config.Namespace,
 		"ingressType":       config.IngressType,
+		"tag":               config.Tag,
 	}
 
 	if config.IngressPort != 0 {

--- a/pkg/operator/controller/instance_controller.go
+++ b/pkg/operator/controller/instance_controller.go
@@ -158,7 +158,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		", Namespace: ", instance.Spec.Namespace,
 		", LogLevel: ", instance.Spec.LogLevel,
 		", ContainerRegistry: ", instance.Spec.ContainerRegistry,
-		", ImageTag: ", instance.Spec.ImageTag,
+		", Tag: ", instance.Spec.Tag,
 	)
 
 	// Set Finalizer if needed
@@ -253,7 +253,7 @@ func (r *InstanceReconciler) applyControlplane(ctx context.Context, instance *cl
 		Containers: []corev1.Container{
 			{
 				Name:            ControlPlaneName,
-				Image:           instance.Spec.ContainerRegistry + ControlPlaneName + ":" + instance.Spec.ImageTag,
+				Image:           instance.Spec.ContainerRegistry + ControlPlaneName + ":" + instance.Spec.Tag,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Args:            []string{"--log-level", instance.Spec.LogLevel},
 				Ports: []corev1.ContainerPort{
@@ -331,7 +331,7 @@ func (r *InstanceReconciler) applyDataplane(ctx context.Context, instance *clust
 		Containers: []corev1.Container{
 			{
 				Name:  "dataplane",
-				Image: instance.Spec.ContainerRegistry + DataplaneImage + ":" + instance.Spec.ImageTag,
+				Image: instance.Spec.ContainerRegistry + DataplaneImage + ":" + instance.Spec.Tag,
 				Args: []string{
 					"--log-level", instance.Spec.LogLevel,
 					"--controlplane-host", ControlPlaneName,

--- a/pkg/operator/controller/instance_controller_test.go
+++ b/pkg/operator/controller/instance_controller_test.go
@@ -235,7 +235,7 @@ func TestClusterLinkController(t *testing.T) {
 		goReplicas := 2
 		loglevel := "debug"
 		containerRegistry := "quay.com"
-		imageTag := "v1.0.1"
+		tag := "v0.0.1"
 		cp := &appsv1.Deployment{}
 		dp := &appsv1.Deployment{}
 
@@ -247,20 +247,20 @@ func TestClusterLinkController(t *testing.T) {
 		cl.Spec.DataPlane.Type = clusterlink.DataplaneTypeGo
 		cl.Spec.DataPlane.Replicas = goReplicas
 		cl.Spec.LogLevel = loglevel
-		cl.Spec.ImageTag = imageTag
+		cl.Spec.Tag = tag
 		cl.Spec.ContainerRegistry = containerRegistry
 		err = k8sClient.Update(ctx, &cl)
 		require.Nil(t, err)
 
 		/// Check controlplane
 		checkResourceCreated(t, cpID, cp)
-		cpImage := containerRegistry + "/" + controller.ControlPlaneName + ":" + imageTag
+		cpImage := containerRegistry + "/" + controller.ControlPlaneName + ":" + tag
 		require.Equal(t, cpImage, cp.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, loglevel, cp.Spec.Template.Spec.Containers[0].Args[1])
 
 		/// Check dataplane
 		checkResourceCreated(t, dpID, dp)
-		goImage := containerRegistry + "/" + controller.GoDataPlaneName + ":" + imageTag
+		goImage := containerRegistry + "/" + controller.GoDataPlaneName + ":" + tag
 		require.Equal(t, goImage, dp.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, int32(goReplicas), *dp.Spec.Replicas)
 		require.Equal(t, loglevel, dp.Spec.Template.Spec.Containers[0].Args[1])

--- a/tests/e2e/k8s/util/k8s_yaml.go
+++ b/tests/e2e/k8s/util/k8s_yaml.go
@@ -67,6 +67,7 @@ func (f *Fabric) generateK8SYAML(p *peer, cfg *PeerConfig) (string, error) {
 		LogLevel:                logLevel,
 		ContainerRegistry:       "",
 		Namespace:               f.namespace,
+		Tag:                     "latest",
 	})
 	if err != nil {
 		return "", err
@@ -281,6 +282,7 @@ func (f *Fabric) generateClusterlinkInstance(name string, p *peer, cfg *PeerConf
 		DataplaneType:     cfg.DataplaneType,
 		LogLevel:          logLevel,
 		ContainerRegistry: "docker.io/library", // Tell kind to use local image.
+		Tag:               "latest",
 		Namespace:         f.namespace,
 		IngressType:       "NodePort",
 	}, name)


### PR DESCRIPTION
Add a version flag to create and deploy peers to be able to deploy different versions of ClusterLink (not just the latest).