### PR TITLE
tests/e2e/k8s: Fix dataplane log-level setting

### DIFF
--- a/tests/e2e/k8s/util/k8s_yaml.go
+++ b/tests/e2e/k8s/util/k8s_yaml.go
@@ -245,10 +245,8 @@ spec:
 }
 
 func changeDataplaneDebugLevel(yaml, logLevel string) (string, error) {
-	search := `dataplane
-          args: ["--log-level", "debug"`
-	replace := `dataplane
-          args: ["--log-level", "` + logLevel + `"`
+	search := `args: ["--log-level", "debug", "--controlplane-host"`
+	replace := `args: ["--log-level", "` + logLevel + `", "--controlplane-host"`
 	return replaceOnce(yaml, search, replace)
 }
 


### PR DESCRIPTION
This PR fixes the function responsible for setting the dataplane debug level.
It was recently broken when introducing the image-tag CLI parameter.