### PR TITLE
[website] Move menu items to _index.md front matter

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -181,20 +181,12 @@ enable = false
   desc = "Discuss development issues around the project"
 
 #-- main menu
-[[menu.main]]
-name = "About"
-weight = 1
-url = "/about/"
-
-[[menu.main]]
-name = "Docs"
-weight = 10
-url = "/docs/"
-pre = "<i class='fa-solid fa-book'></i>"
+# most sections are populated from markdown files and their front matter.
+# below add menu items that do not have associated content on the website
 
 [[menu.main]]
 name = "GitHub"
-weight = 20
+weight = 50
 url = "https://github.com/clusterlink-net/clusterlink/"
 pre = "<i class='fa-brands fa-github'></i>"
 

--- a/website/content/en/about/_index.md
+++ b/website/content/en/about/_index.md
@@ -2,11 +2,12 @@
 title: About ClusterLink
 linkTitle: About
 description: Why and where should you use ClusterLink
+menu: {main: {weight: 10, pre: "<i class='fa-solid fa-info-circle'></i>" }}
 ---
 
 {{% blocks/section color="secondary" %}}
 
-# About ClusterLink
+## About ClusterLink
 
 {{% pageinfo %}}
 ClusterLink is in **alpha** status and not ready for production use.

--- a/website/content/en/docs/_index.md
+++ b/website/content/en/docs/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Documentation
-linkTitle: Documentation
+linkTitle: Docs
+menu: {main: {weight: 30, pre: "<i class='fa-solid fa-book'></i>" }}
 ---


### PR DESCRIPTION
... instead of defining the main menu entries in `config.toml`.
Only remaining menu item in the config is GitHub link which does not (and should not) have a corresponding markdown file as it is an external link.