### PR TITLE
[website] Add blog collection and sample entry

### DIFF
--- a/website/content/en/blog/_index.md
+++ b/website/content/en/blog/_index.md
@@ -1,0 +1,8 @@
+---
+title: ClusterLink Blogs
+linkTitle: Blog
+menu: {main: {weight: 20, pre: "<i class='fa-solid fa-blog'></i>" }}
+draft: true
+---
+
+Coming Soon!

--- a/website/content/en/blog/hello.md
+++ b/website/content/en/blog/hello.md
@@ -1,0 +1,22 @@
+---
+title: "Long Page Title"
+linkTitle: ShortNavigationTitle
+date: 2024-03-20
+author: Etai Lev Ran
+description: >-
+     Welcome to ClusterLink
+type: blog
+draft: true
+---
+
+## Hello
+
+That's it. Just wanted to say Hi.
+
+Be gone now!
+
+Oh, and if you delete the `draft: true` entry in the front matter above,
+ it'll actually show up on the website. For now it's our secret.
+
+Blog entries will be displayed in reverse chronological order, based on the
+ `date` entry in the front matter.


### PR DESCRIPTION
currently set `draft: true` so section and entry are both not rendered.

References #410 