### PR TITLE
controlplane/authz: use policyengine response fields for connection request

### DIFF
--- a/pkg/controlplane/authz/manager.go
+++ b/pkg/controlplane/authz/manager.go
@@ -279,9 +279,19 @@ func (m *Manager) authorizeEgress(req *egressAuthorizationRequest) (*egressAutho
 		return nil, fmt.Errorf("missing client for peer: %s", target)
 	}
 
+	DstName := authResp.DstName
+	DstNamespace := authResp.DstNamespace
+	if DstName == "" { // TODO- remove when controlplane will support only CRD mode.
+		DstName = req.ImportName
+	}
+
+	if DstNamespace == "" { // TODO- remove when controlplane will support only CRD mode.
+		DstNamespace = req.ImportNamespace
+	}
+
 	serverResp, err := client.Authorize(&cpapi.AuthorizationRequest{
-		ServiceName:      req.ImportName,
-		ServiceNamespace: req.ImportNamespace,
+		ServiceName:      DstName,
+		ServiceNamespace: DstNamespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to get access token from peer: %w", err)

--- a/pkg/policyengine/PolicyDispatcher.go
+++ b/pkg/policyengine/PolicyDispatcher.go
@@ -153,6 +153,7 @@ func (pH *PolicyHandler) decideOutgoingConnection(
 	return connectivitypdp.ConnectionResponse{
 		Action:       crds.AccessPolicyActionAllow,
 		DstPeer:      tgt.Peer,
+		DstName:      tgt.ExportName,
 		DstNamespace: tgt.ExportNamespace,
 	}, nil
 }

--- a/pkg/policyengine/connectivitypdp/connection_request.go
+++ b/pkg/policyengine/connectivitypdp/connection_request.go
@@ -38,5 +38,6 @@ type ConnectionRequest struct {
 type ConnectionResponse struct {
 	Action       v1alpha1.AccessPolicyAction
 	DstPeer      string
+	DstName      string
 	DstNamespace string
 }


### PR DESCRIPTION
Use policyengine response fields for connection request and add import name to the response