### PR TITLE
policyengine/PolicyDispatcher: allow to delete unprivileged policy

### DIFF
--- a/pkg/controlplane/authz/controllers.go
+++ b/pkg/controlplane/authz/controllers.go
@@ -34,8 +34,7 @@ func CreateControllers(mgr *Manager, controllerManager ctrl.Manager, crdMode boo
 				return mgr.addAccessPolicy(object.(*v1alpha1.AccessPolicy))
 			},
 			DeleteHandler: func(ctx context.Context, name types.NamespacedName) error {
-				mgr.deleteAccessPolicy(name)
-				return nil
+				return mgr.deleteAccessPolicy(name)
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Add delete unprivileged policy function,
(Delete privileged policy is still missing -can be done by adding finalizer before deleting to the policies or separate access policy CRDS to privileged and non-privileged)