### PR TITLE
Set gofumpt version to 0.6.0 instead of latest

### DIFF
--- a/.devcontainer/dev/post-create.sh
+++ b/.devcontainer/dev/post-create.sh
@@ -19,3 +19,4 @@ go install golang.org/x/tools/cmd/goimports@latest
 go install github.com/mfridman/tparse@latest
 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+go install mvdan.cc/gofumpt@v0.6.0

--- a/hack/install-devtools.sh
+++ b/hack/install-devtools.sh
@@ -74,7 +74,7 @@ if [ -z "$(which tparse)" ] || [ "$1" = "--force" ]; then
 fi
 
 #-- gofumpt
-VERSION=latest
+VERSION="0.6.0"
 if [ -z "$(which gofumpt)" ] || [ "$1" = "--force" ]; then
   echo installing gofumpt "($VERSION)"
   go install "mvdan.cc/gofumpt@$VERSION"


### PR DESCRIPTION
Latest gofumpt requires Go 1.21 and we're currently on 1.20.x