### PR TITLE
controlplane/control: Fix interval while peer is unhealthy

### DIFF
--- a/pkg/controlplane/control/peer.go
+++ b/pkg/controlplane/control/peer.go
@@ -109,6 +109,9 @@ func (m *peerMonitor) Start() {
 
 		heartbeatOK := m.client.GetHeartbeat() == nil
 		if healthy == heartbeatOK {
+			if !healthy {
+				ticker.Reset(unhealthyInterval)
+			}
 			strikeCount = 0
 		} else {
 			if heartbeatOK {


### PR DESCRIPTION
When an unhealthy peer suddently responds to a healthcheck, its monitor immediately switches to using the healthInterval.
This PR makes a fix to switch back to using the unhealthyInterval if the peer returns to not responding to healthchecks.