### PR TITLE
cmd/clusterlink: Add fabric name to CLI

### DIFF
--- a/cmd/clusterlink/cmd/deploy/deploy_peer.go
+++ b/cmd/clusterlink/cmd/deploy/deploy_peer.go
@@ -38,6 +38,8 @@ import (
 type PeerOptions struct {
 	// Name of the peer to deploy.
 	Name string
+	// Name of the fabric that the peer belongs to.
+	Fabric string
 	// Namespace where the ClusterLink components are deployed.
 	Namespace string
 	// CertDir is the directory where the certificates for the fabric and peer are located.
@@ -83,6 +85,7 @@ func NewCmdDeployPeer() *cobra.Command {
 // AddFlags adds flags to fs and binds them to options.
 func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
+	fs.StringVar(&o.Fabric, "fabric", config.DefaultFabric, "Fabric name.")
 	fs.StringVar(&o.CertDir, "cert-dir", ".", "The directory where the certificates for the fabric and peer are located.")
 	fs.StringVar(&o.Namespace, "namespace", app.SystemNamespace,
 		"Namespace where the ClusterLink components are deployed.")
@@ -106,7 +109,7 @@ func (o *PeerOptions) RequiredFlags() []string {
 
 // Run the 'deploy peer' subcommand.
 func (o *PeerOptions) Run() error {
-	peerDir := path.Join(o.CertDir, o.Name)
+	peerDir := path.Join(o.CertDir, config.PeerDirectory(o.Name, o.Fabric))
 	if _, err := os.Stat(peerDir); err != nil {
 		return fmt.Errorf("failed to open certificates folder: %w", err)
 	}

--- a/cmd/clusterlink/config/config.go
+++ b/cmd/clusterlink/config/config.go
@@ -22,6 +22,8 @@ const (
 	PrivateKeyFileName = "key.pem"
 	// CertificateFileName is the filename used by certificate files.
 	CertificateFileName = "cert.pem"
+	// DefaultFabric is the default fabric name.
+	DefaultFabric = "default_fabric"
 	// DockerRunFile is the filename of the docker-run script.
 	DockerRunFile = "docker-run.sh"
 	// GWCTLInitFile is the filename of the gwctl-init script.
@@ -49,26 +51,36 @@ const (
 )
 
 // FabricDirectory returns the base path of the fabric.
-func FabricDirectory() string {
-	return "."
+func FabricDirectory(name string) string {
+	return filepath.Join(".", name)
 }
 
 // PeerDirectory returns the base path for a specific peer.
-func PeerDirectory(peer string) string {
-	return filepath.Join(FabricDirectory(), peer)
+func PeerDirectory(peer, fabric string) string {
+	return filepath.Join(FabricDirectory(fabric), peer)
 }
 
 // ControlplaneDirectory returns the path for a controlplane server.
-func ControlplaneDirectory(peer string) string {
-	return filepath.Join(PeerDirectory(peer), ControlplaneDirectoryName)
+func ControlplaneDirectory(peer, fabric string) string {
+	return filepath.Join(PeerDirectory(peer, fabric), ControlplaneDirectoryName)
 }
 
 // DataplaneDirectory returns the path for a dataplane server.
-func DataplaneDirectory(peer string) string {
-	return filepath.Join(PeerDirectory(peer), DataplaneDirectoryName)
+func DataplaneDirectory(peer, fabric string) string {
+	return filepath.Join(PeerDirectory(peer, fabric), DataplaneDirectoryName)
 }
 
 // GWCTLDirectory returns the path for a gwctl instance.
-func GWCTLDirectory(peer string) string {
-	return filepath.Join(PeerDirectory(peer), GWCTLDirectoryName)
+func GWCTLDirectory(peer, fabric string) string {
+	return filepath.Join(PeerDirectory(peer, fabric), GWCTLDirectoryName)
+}
+
+// FabricCertificate returns the fabric certificate name.
+func FabricCertificate(name string) string {
+	return filepath.Join(FabricDirectory(name), CertificateFileName)
+}
+
+// FabricKey returns the fabric key name.
+func FabricKey(name string) string {
+	return filepath.Join(FabricDirectory(name), PrivateKeyFileName)
 }

--- a/demos/utils/common.py
+++ b/demos/utils/common.py
@@ -40,7 +40,7 @@ def createPeer(name, dir, logLevel="info", dataplane="envoy",localImage=False):
 
 # applyPeer deploys the peer certificates and yaml to the cluster.
 def applyPeer(name,dir):
-    runcmd(f"kubectl apply -f {dir}/{name}/k8s.yaml")
+    runcmd(f"kubectl apply -f {dir}/default_fabric/{name}/k8s.yaml")
     waitPod("cl-controlplane")
     waitPod("cl-dataplane")
     waitPod("gwctl")
@@ -48,7 +48,7 @@ def applyPeer(name,dir):
 # startGwctl sets gwctl configuration
 def startGwctl(name,geIP, gwPort, testOutputFolder):
     runcmd(f'gwctl init --id {name} --gwIP {geIP} --gwPort {gwPort}  --dataplane mtls \
-    --certca {testOutputFolder}/cert.pem --cert {testOutputFolder}/{name}/gwctl/cert.pem --key {testOutputFolder}/{name}/gwctl/key.pem')
+    --certca {testOutputFolder}/default_fabric/cert.pem --cert {testOutputFolder}/default_fabric/{name}/gwctl/cert.pem --key {testOutputFolder}/default_fabric/{name}/gwctl/key.pem')
 
 # Log Functions
 # runcmd runs os system command.

--- a/pkg/bootstrap/cert.go
+++ b/pkg/bootstrap/cert.go
@@ -38,9 +38,9 @@ func (c *Certificate) RawKey() []byte {
 }
 
 // CreateFabricCertificate creates a clusterlink fabric (root) certificate.
-func CreateFabricCertificate() (*Certificate, error) {
+func CreateFabricCertificate(name string) (*Certificate, error) {
 	cert, err := createCertificate(&certificateConfig{
-		Name: "root",
+		Name: name,
 		IsCA: true,
 	})
 	if err != nil {

--- a/tests/e2e/k8s/util/fabric.go
+++ b/tests/e2e/k8s/util/fabric.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 
+	"github.com/clusterlink-net/clusterlink/cmd/clusterlink/config"
 	"github.com/clusterlink-net/clusterlink/pkg/apis/clusterlink.net/v1alpha1"
 	"github.com/clusterlink-net/clusterlink/pkg/bootstrap"
 	"github.com/clusterlink-net/clusterlink/pkg/bootstrap/platform"
@@ -365,7 +366,7 @@ func (f *Fabric) Namespace() string {
 
 // NewFabric returns a new empty fabric.
 func NewFabric() (*Fabric, error) {
-	cert, err := bootstrap.CreateFabricCertificate()
+	cert, err := bootstrap.CreateFabricCertificate(config.DefaultFabric)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create fabric certificate: %w", err)
 	}

--- a/website/content/en/docs/concepts/fabric.md
+++ b/website/content/en/docs/concepts/fabric.md
@@ -36,9 +36,7 @@ To create a new Fabric certificate authority (CA), execute the following CLI com
 clusterlink create fabric --name <fabric_name>
 ```
 
-This command will create the CA files `<fabric_name>.cert` and `<fabric_name>.key` in the
- current directory. While you will need access to these files to create the peers` gateway
- certificates later, the private key file should be protected and not shared with others.
+This command will create the CA files `cert.pem` and `key.pem` in a folder named <fabric_name>. The `--name` option is optional, and by default, "default_fabric" will be used. While you will need access to these files to create the peers` gateway certificates later, the private key file should be protected and not shared with others.
 
 ## Related tasks
 

--- a/website/content/en/docs/concepts/peers.md
+++ b/website/content/en/docs/concepts/peers.md
@@ -45,13 +45,12 @@ clusterlink create peer-cert --name <peer_name> --fabric <fabric_name>
 ```
 
 {{< notice tip >}}
-The Fabric CA files (certificate and private key) are expected in the current
-working directory (i.e., `./<fabric_name>.crt` and `./<fabric_name>.key`).
+The Fabric CA files (certificate and private key) are expected to be in a subdirectory (i.e., `./<fabric_name>/cert.name` and `./<fabric_name>/key.pem`).
 {{< /notice >}}
 
-This will create the certificate and private key files (`<peer_name>.cert` and
- `<peer_name>.key`, respectively) for the new peer. By default, the files are
- created in a subdirectory named `<peer_name>` under the current working directory.
+This will create the certificate and private key files (`cert.pem` and
+ `key.pem`, respectively) for the new peer. By default, the files are
+ created in a subdirectory named `<peer_name>` under the subdirectory of the fabric `<fabric_name>`.
  You can override the default by setting the `--output <path>` option.
 
 {{< notice info >}}

--- a/website/content/en/docs/getting-started/users.md
+++ b/website/content/en/docs/getting-started/users.md
@@ -37,7 +37,7 @@ To set up ClusterLink on a Kubernetes cluster, follow these steps:
     clusterlink create fabric --name <fabric_name>
     ```
 
-    This command will create the CA files `<fabric_name>.cert` and `<fabric_name>.key` in the current folder.
+    This command will create the CA files `cert.pem` and `key.pem` in a folder named <fabric_name>. The `--name` option is optional, and by default, "default_fabric" will be used.
 
 1. {{< anchor create-peer-certs >}}Create peer certificates.
 
@@ -47,19 +47,19 @@ To set up ClusterLink on a Kubernetes cluster, follow these steps:
     clusterlink create peer-cert --name <peer_name> --fabric <fabric_name>
     ```
 
-    This command will create the certificate files `<peer_name>.cert` and `<peer_name>.key` in a folder named <peer_name>. The `--path <path>` flag can be used to change the folder location.
+    This command will create the certificate files `cert.pem` and `key.pem` in a folder named <fabric_name/peer_name>. The `--path <path>` flag can be used to change the folder location.The `--name` option is optional, and by default, "default_fabric" will be used.
 
 1. {{< anchor install-cl-operator >}}Install ClusterLink.
 
     To install ClusterLink on the peer, first install the ClusterLink deployment operator.
 
     ```sh
-    clusterlink peer deploy --start
+    clusterlink peer deploy --autostart --name <peer_name> --fabric <fabric_name>
     ```
 
     This command will deploy the ClusterLink operator on the `clusterlink-operator` namespace and convert the peer certificates to secrets in the namespace.
-    The command assumes that `kubectl` is set to the correct peer (Kubernetes cluster) and that the certificates were created in the local folder. If they were not, use the flag `--path <path>`.
-    The `--start` option will deploy the ClusterLink components in the `clusterlink-system` namespace, and the ClusterLink project will start to run in the cluster.
+    The command assumes that `kubectl` is set to the correct peer (Kubernetes cluster) and that the certificates were created in the local folder. If they were not, use the flag `--path <path>`. The `--fabric` option is optional, and by default, "default_fabric" will be used.
+    The `--autostart` option will deploy the ClusterLink components in the `clusterlink-system` namespace, and the ClusterLink project will start to run in the cluster.
 
 To deploy ClusterLink on another cluster, please repeat steps 2-3 in the console with access to the cluster.
 
@@ -68,18 +68,18 @@ To deploy ClusterLink on another cluster, please repeat steps 2-3 in the console
 * Setting ClusterLink namespace:
 
     ```sh
-    clusterlink peer deploy --start --start-namespace <namespace>
+    clusterlink peer deploy --autostart --name <peer_name> --fabric <fabric_name> --namespace <namespace>
     ```
 
-    The `--start-namespace` determines the namespace where the ClusterLink components are deployed. Note that you must set `--start`, and the namespace should already exist.
+    The `--namespace` determines the namespace where the ClusterLink components are deployed. Note that you must set `--autostart`, and the namespace should already exist.
 
 * Setting ClusterLink Ingress type:
 
     ```sh
-    clusterlink peer deploy --start --start-ingress <ingress_type>
+    clusterlink peer deploy --autostart --name <peer_name> --fabric <fabric_name> --ingress <ingress_type>
     ```
 
-    The `--start-ingress` controls the ClusterLink ingress type, with `LoadBalancer` being the default. If you're using a Kind cluster, replace `<ingress_type>` with `NodePort`. For a cluster running in a cloud environment, use `LoadBalancer`.Note that you must set `--start` when you use this flag.
+    The `--ingress` controls the ClusterLink ingress type, with `LoadBalancer` being the default. If you're using a Kind cluster, replace `<ingress_type>` with `NodePort`. For a cluster running in a cloud environment, use `LoadBalancer`.Note that you must set `--autostart` when you use this flag.
 
 * {{< anchor deploy-crd-instance >}}Full configuration setting using ClusterLink CRD instance:
 


### PR DESCRIPTION
Add an option to specify the fabric name when creating certificates, by default, will use "default_fabric".