### PR TITLE
pkg/apis: Validate import names

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/config/crds/clusterlink.net_imports.yaml
+++ b/config/crds/clusterlink.net_imports.yaml
@@ -149,6 +149,9 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: import name cannot exceed 63 chars
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/pkg/apis/clusterlink.net/v1alpha1/import.go
+++ b/pkg/apis/clusterlink.net/v1alpha1/import.go
@@ -19,6 +19,7 @@ import (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="import name cannot exceed 63 chars"
 
 // Import defines a service that is being imported to the local Peer from a remote Peer.
 type Import struct {

--- a/tests/e2e/k8s/util/kind.go
+++ b/tests/e2e/k8s/util/kind.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/support"
 	"sigs.k8s.io/e2e-framework/support/kind"
 
 	clusterlink "github.com/clusterlink-net/clusterlink/pkg/apis/clusterlink.net/v1alpha1"
@@ -84,7 +85,7 @@ type KindCluster struct {
 	created          sync.WaitGroup
 	name             string
 	ip               string
-	cluster          *kind.Cluster
+	cluster          support.E2EClusterProviderWithImageLoader
 	resources        *resources.Resources
 	clientset        *kubernetes.Clientset
 	nodeportServices map[string]*map[string]*v1.Service // map[namespace][name]
@@ -564,7 +565,7 @@ func (c *KindCluster) WaitForDeletion(obj k8s.Object) error {
 // NewKindCluster returns a new yet to be running kind cluster.
 func NewKindCluster(name string) *KindCluster {
 	return &KindCluster{
-		cluster:          kind.NewCluster(name),
+		cluster:          kind.NewCluster(name).WithVersion("v0.22.0").(support.E2EClusterProviderWithImageLoader),
 		name:             name,
 		nodeportServices: make(map[string]*map[string]*v1.Service),
 	}


### PR DESCRIPTION
This PR adds an API-server validation for imports to be limited to 63 characters.
This ensures that the respective service name will be valid.

Ref #482