### PR TITLE
Remove duplicated text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ ClusterLink will be used in a cloud native environment with other
 - Certificate management: ClusterLink uses certificates and trust bundles provided to
  it. It does not manage certificate lifetimes, rotation, etc. - these are delegated to external tools.
 - Enabling IP level connectivity between sites. ClusterLink uses existing network paths.
-- Pod to Pod communications. ClusterLink works at the level of `Service`s (but you could create a Service per Pod
-Pod to Pod communications. ClusterLink works at the level of `Service`s , but can support this scenario by creating a service per pod.
+- Pod to Pod communications. ClusterLink works at the level of `Service`s. You can support Pod-to-Pod communications by creating a service per pod.
 
 ## Communications
 


### PR DESCRIPTION
Remove duplicated text regarding pod-to-pod communications. Splitting the sentence and removing "but".