### PR TITLE
Disable GitInfo on production deployment

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -18,7 +18,7 @@ serve: ; $(info running locally with env=production...)
 	@hugo server --gc --cleanDestinationDir --disableFastRender
 
 serve-dev: ; $(info running locally env=dev \(drafts and future\)...)
-	@hugo server --gc --cleanDestinationDir --disableFastRender --buildDrafts --buildFuture
+	@hugo server --gc --cleanDestinationDir --disableFastRender --buildDrafts --buildFuture --enableGitInfo
 
 checklinks: ; $(info running link check on https://clusterlink.net...)
 	@muffet -c 16 -b 65536  --rate-limit 16 https://clusterlink.net

--- a/website/config.toml
+++ b/website/config.toml
@@ -11,7 +11,7 @@ enableMissingTranslationPlaceholders = true
 enableRobotsTXT = true
 
 # Will give values to .Lastmod etc.
-enableGitInfo = true
+enableGitInfo = false
 
 # Comment out to enable taxonomies in Docsy
 # disableKinds = ["taxonomy", "taxonomyTerm"]


### PR DESCRIPTION
GitInfo can still be (and is) enabled on local deployments via the `--enableGitInfo` Hugo command line flag.

Fixes #515 