### PR TITLE
cmd/clusterlink: Introduce delete peer command

### DIFF
--- a/cmd/clusterlink/cmd/delete/delete.go
+++ b/cmd/clusterlink/cmd/delete/delete.go
@@ -11,28 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package deletion
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/clusterlink-net/clusterlink/cmd/clusterlink/cmd/create"
-	deletion "github.com/clusterlink-net/clusterlink/cmd/clusterlink/cmd/delete"
-	"github.com/clusterlink-net/clusterlink/cmd/clusterlink/cmd/deploy"
 )
 
-// NewCLADMCommand returns a cobra.Command to run the clusterlink command.
-func NewCLADMCommand() *cobra.Command {
+// NewCmdDelete returns a cobra.Command to run the delete command.
+func NewCmdDelete() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:          "clusterlink",
-		Short:        "clusterlink: bootstrap a clink fabric",
-		Long:         `clusterlink: bootstrap a clink fabric`,
-		SilenceUsage: true,
+		Use:   "delete",
+		Short: "Delete ClusterLink resources",
+		Long:  "Delete ClusterLink resources",
 	}
 
-	cmds.AddCommand(create.NewCmdCreate())
-	cmds.AddCommand(deploy.NewCmdDeploy())
-	cmds.AddCommand(deletion.NewCmdDelete())
+	cmds.AddCommand(NewCmdDeletePeer())
 
 	return cmds
 }

--- a/cmd/clusterlink/cmd/delete/delete_peer.go
+++ b/cmd/clusterlink/cmd/delete/delete_peer.go
@@ -1,0 +1,185 @@
+// Copyright 2023 The ClusterLink Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+
+	// Importing this package for initializing the OIDC authentication plugin for client-go.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+
+	"github.com/clusterlink-net/clusterlink/cmd/cl-controlplane/app"
+	configfiles "github.com/clusterlink-net/clusterlink/config"
+	apis "github.com/clusterlink-net/clusterlink/pkg/apis/clusterlink.net/v1alpha1"
+	"github.com/clusterlink-net/clusterlink/pkg/bootstrap/platform"
+)
+
+// PeerOptions contains everything necessary to create and run a 'delete peer' subcommand.
+type PeerOptions struct {
+	// Name of the peer to delete.
+	Name string
+	// Namespace where the ClusterLink components and secrets are deployed.
+	Namespace string
+}
+
+// NewCmdDeletePeer returns a cobra.Command to run the 'delete peer' subcommand.
+func NewCmdDeletePeer() *cobra.Command {
+	opts := &PeerOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "peer",
+		Short: "Delete ClusterLink components from the cluster.",
+		Long:  `Delete ClusterLink components from the cluster.`,
+
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return opts.Run()
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	for _, flag := range opts.RequiredFlags() {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			fmt.Printf("Error marking required flag '%s': %v\n", flag, err)
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}
+
+// AddFlags adds flags to fs and binds them to options.
+func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.Name, "name", "", "Peer name.")
+	fs.StringVar(&o.Namespace, "namespace", app.SystemNamespace,
+		"Namespace where the ClusterLink secrets are deployed.")
+}
+
+// RequiredFlags are the names of flags that must be explicitly specified.
+func (o *PeerOptions) RequiredFlags() []string {
+	return []string{"name"}
+}
+
+// Run the 'delete peer' subcommand.
+func (o *PeerOptions) Run() error {
+	// Create k8s resources
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	resource, err := resources.New(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := apis.AddToScheme(resource.GetScheme()); err != nil {
+		return err
+	}
+
+	// List all instances of the CR
+	instList := &apis.InstanceList{}
+	err = resource.List(context.Background(), instList)
+	if client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
+		return fmt.Errorf("unable to get instances list: %w", err)
+	}
+
+	// Delete each instance.
+	for i := range instList.Items {
+		err = resource.Delete(context.Background(), &instList.Items[i])
+		if err != nil {
+			fmt.Printf("Error deleting instance %s in namespace %s: %v\n", instList.Items[i].Name, instList.Items[i].Namespace, err)
+			continue
+		}
+
+		if err := o.waitForInstanceDeletion(resource, &instList.Items[i]); err != nil {
+			return err
+		}
+	}
+
+	// Delete operator
+	if err := o.deleteDir("operator/manager/*", resource); err != nil {
+		return err
+	}
+
+	if err := o.deleteDir("operator/rbac/*", resource); err != nil {
+		return err
+	}
+
+	if err := o.deleteDir("crds/*", resource); err != nil {
+		return err
+	}
+
+	// Delete secrets
+	platformCfg := &platform.Config{
+		Peer:      o.Name,
+		Namespace: o.Namespace,
+	}
+
+	secretConfig, err := platform.K8SEmptyCertificateConfig(platformCfg)
+	if err != nil {
+		return err
+	}
+
+	err = decoder.DecodeEach(
+		context.Background(),
+		strings.NewReader(string(secretConfig)),
+		decoder.DeleteIgnoreNotFound(resource),
+		decoder.MutateNamespace(o.Namespace),
+	)
+	if err != nil {
+		return fmt.Errorf("fail to delete certificate secrets %w", err)
+	}
+
+	return nil
+}
+
+// deleteDir deletes K8s yaml from a directory.
+func (o *PeerOptions) deleteDir(dir string, resource *resources.Resources) error {
+	err := decoder.DecodeEachFile(context.Background(), configfiles.ConfigFiles, dir, decoder.DeleteIgnoreNotFound(resource))
+	if err != nil {
+		return fmt.Errorf("failed to delete directory %s - %w", dir, err)
+	}
+
+	return nil
+}
+
+// waitForInstanceDeletion waits for the deletion of the instance to complete.
+func (o *PeerOptions) waitForInstanceDeletion(resource *resources.Resources, inst *apis.Instance) error {
+	for t := time.Now(); time.Since(t) < time.Second*60; time.Sleep(time.Millisecond * 500) {
+		instance := &apis.Instance{}
+		err := resource.Get(context.Background(), inst.Name, inst.Namespace, instance)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return nil // Instance deletion completed
+			}
+			return err // Error occurred during deletion
+		}
+	}
+
+	return fmt.Errorf("timeout exceeded while waiting for instance deletion")
+}

--- a/pkg/bootstrap/platform/k8s.go
+++ b/pkg/bootstrap/platform/k8s.go
@@ -174,8 +174,8 @@ spec:
             secretName: cl-dataplane
       containers:
         - name: dataplane
-          image: {{.containerRegistry}}{{ 
-          if (eq .dataplaneType .dataplaneTypeEnvoy) }}cl-dataplane{{ 
+          image: {{.containerRegistry}}{{
+          if (eq .dataplaneType .dataplaneTypeEnvoy) }}cl-dataplane{{
           else }}cl-go-dataplane{{ end }}:{{.tag}}
           args: ["--log-level", "{{.logLevel}}", "--controlplane-host", "cl-controlplane"]
           imagePullPolicy: IfNotPresent
@@ -436,4 +436,28 @@ func K8SClusterLinkInstanceConfig(config *Config, name string) ([]byte, error) {
 	}
 
 	return clConfig.Bytes(), nil
+}
+
+// K8SEmptyCertificateConfig returns Kubernetes empty secrets for the control plane and data plane,
+// used for deleting the secrets.
+func K8SEmptyCertificateConfig(config *Config) ([]byte, error) {
+	args := map[string]interface{}{
+		"fabricCA":         "",
+		"peerCA":           "",
+		"controlplaneCert": "",
+		"controlplaneKey":  "",
+		"dataplaneCert":    "",
+		"dataplaneKey":     "",
+		"gwctlCert":        "",
+		"gwctlKey":         "",
+		"namespace":        config.Namespace,
+	}
+
+	var certConfig bytes.Buffer
+	t := template.Must(template.New("").Parse(certsTemplate))
+	if err := t.Execute(&certConfig, args); err != nil {
+		return nil, fmt.Errorf("cannot create k8s certificate configuration from template: %w", err)
+	}
+
+	return certConfig.Bytes(), nil
 }

--- a/website/content/en/docs/getting-started/users.md
+++ b/website/content/en/docs/getting-started/users.md
@@ -80,8 +80,26 @@ multi-cluster connectivity for applications using two or more clusters.
 
 ## Uninstall ClusterLink
 
-To uninstall the ClusterLink CLI, use the following command:
+1. To remove a ClusterLink instance from the cluster, please delete the ClusterLink instance custom resource.
+   The ClusterLink operator will subsequently remove all instance components (control-plane, data-plane, and ingress service).
 
-```sh
-rm `which clusterlink`
-```
+   ```sh
+   kubectl delete instances.clusterlink.net  -A --all
+   ```
+
+2. To completely remove ClusterLink from the cluster, including the operator, CRDs, namespaces, and instances,
+   use the following command:
+
+   ```sh
+   clusterlink delete peer --name peer1
+   ```
+
+{{< notice note >}}
+This command  using the current `kubectl` context.
+{{< /notice >}}
+
+3. To uninstall the ClusterLink CLI, use the following command:
+
+   ```sh
+   rm `which clusterlink`
+   ```


### PR DESCRIPTION
Add delete peer command that completely removes ClusterLink from the cluster,
including the operator, CRDs, namespaces, and instances.