### PR TITLE
cmd/clusterlink: Fix path flag

### DIFF
--- a/cmd/clusterlink/cmd/create/create_fabric.go
+++ b/cmd/clusterlink/cmd/create/create_fabric.go
@@ -25,13 +25,16 @@ import (
 
 // FabricOptions contains everything necessary to create and run a 'createfabric' subcommand.
 type FabricOptions struct {
-	// Name of the peer to create.
+	// Name of the fabric to create.
 	Name string
+	// Path where the certificates will be created.
+	Path string
 }
 
 // AddFlags adds flags to fs and binds them to options.
 func (o *FabricOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", config.DefaultFabric, "Fabric name.")
+	fs.StringVar(&o.Path, "path", ".", "Path where the certificates will be created.")
 }
 
 // NewCmdCreateFabric returns a cobra.Command to run the 'create fabric' subcommand.
@@ -58,15 +61,15 @@ func (o *FabricOptions) Run() error {
 		return err
 	}
 
-	if err := os.Mkdir(config.FabricDirectory(o.Name), 0o755); err != nil {
+	if err := os.Mkdir(config.FabricDirectory(o.Name, o.Path), 0o755); err != nil {
 		return err
 	}
 	// save certificate to file
-	err = os.WriteFile(config.FabricCertificate(o.Name), fabricCert.RawCert(), 0o600)
+	err = os.WriteFile(config.FabricCertificate(o.Name, o.Path), fabricCert.RawCert(), 0o600)
 	if err != nil {
 		return err
 	}
 
 	// save private key to file
-	return os.WriteFile(config.FabricKey(o.Name), fabricCert.RawKey(), 0o600)
+	return os.WriteFile(config.FabricKey(o.Name, o.Path), fabricCert.RawKey(), 0o600)
 }

--- a/cmd/clusterlink/cmd/create/create_peer.go
+++ b/cmd/clusterlink/cmd/create/create_peer.go
@@ -32,12 +32,15 @@ type PeerOptions struct {
 	Name string
 	// Name of the fabric that the peer belongs to.
 	Fabric string
+	// Path where the certificates will be created.
+	Path string
 }
 
 // AddFlags adds flags to fs and binds them to options.
 func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
 	fs.StringVar(&o.Fabric, "fabric", config.DefaultFabric, "Fabric name.")
+	fs.StringVar(&o.Path, "path", ".", "Path where the certificates will be created.")
 }
 
 // RequiredFlags are the names of flags that must be explicitly specified.
@@ -62,7 +65,7 @@ func (o *PeerOptions) createControlplane(peerCert *bootstrap.Certificate) (*boot
 		return nil, err
 	}
 
-	outDirectory := config.ControlplaneDirectory(o.Name, o.Fabric)
+	outDirectory := config.ControlplaneDirectory(o.Name, o.Fabric, o.Path)
 	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
@@ -80,7 +83,7 @@ func (o *PeerOptions) createDataplane(peerCert *bootstrap.Certificate) (*bootstr
 		return nil, err
 	}
 
-	outDirectory := config.DataplaneDirectory(o.Name, o.Fabric)
+	outDirectory := config.DataplaneDirectory(o.Name, o.Fabric, o.Path)
 	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
@@ -98,7 +101,7 @@ func (o *PeerOptions) createGWCTL(peerCert *bootstrap.Certificate) (*bootstrap.C
 		return nil, err
 	}
 
-	outDirectory := config.GWCTLDirectory(o.Name, o.Fabric)
+	outDirectory := config.GWCTLDirectory(o.Name, o.Fabric, o.Path)
 	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
@@ -120,12 +123,12 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 
-	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric))
+	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}
 
-	peerDirectory := config.PeerDirectory(o.Name, o.Fabric)
+	peerDirectory := config.PeerDirectory(o.Name, o.Fabric, o.Path)
 	if err := os.Mkdir(peerDirectory, 0o755); err != nil {
 		return err
 	}
@@ -135,7 +138,7 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 
-	err = o.saveCertificate(peerCertificate, config.PeerDirectory(o.Name, o.Fabric))
+	err = o.saveCertificate(peerCertificate, peerDirectory)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterlink/cmd/deploy/deploy_peer.go
+++ b/cmd/clusterlink/cmd/deploy/deploy_peer.go
@@ -57,8 +57,8 @@ type PeerOptions struct {
 	Fabric string
 	// Namespace where the ClusterLink components are deployed.
 	Namespace string
-	// CertDir is the directory where the certificates for the fabric and peer are located.
-	CertDir string
+	// Path is the directory where the certificates for the fabric and peer are located.
+	Path string
 	// StartInstance, represents which component to deploy:
 	// `all` (clusterlink control-plane, data-plane and operator), `operator`, or `none`.
 	StartInstance string
@@ -113,7 +113,7 @@ func NewCmdDeployPeer() *cobra.Command {
 func (o *PeerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Name, "name", "", "Peer name.")
 	fs.StringVar(&o.Fabric, "fabric", config.DefaultFabric, "Fabric name.")
-	fs.StringVar(&o.CertDir, "cert-dir", ".", "The directory where the certificates for the fabric and peer are located.")
+	fs.StringVar(&o.Path, "path", ".", "The directory where the certificates for the fabric and peer are located.")
 	fs.StringVar(&o.Namespace, "namespace", app.SystemNamespace,
 		"Namespace where the ClusterLink components are deployed.")
 	fs.StringVar(&o.ContainerRegistry, "container-registry", config.DefaultRegistry,
@@ -145,7 +145,7 @@ func (o *PeerOptions) RequiredFlags() []string {
 
 // Run the 'deploy peer' subcommand.
 func (o *PeerOptions) Run() error {
-	peerDir := path.Join(o.CertDir, config.PeerDirectory(o.Name, o.Fabric))
+	peerDir := config.PeerDirectory(o.Name, o.Fabric, o.Path)
 	if _, err := os.Stat(peerDir); err != nil {
 		return fmt.Errorf("failed to open certificates folder: %w", err)
 	}
@@ -157,27 +157,27 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 	// Read certificates
-	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric))
+	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}
 
-	peerCertificate, err := bootstrap.ReadCertificates(config.PeerDirectory(o.Name, o.Fabric))
+	peerCertificate, err := bootstrap.ReadCertificates(config.PeerDirectory(o.Name, o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}
 
-	controlplaneCert, err := bootstrap.ReadCertificates(config.ControlplaneDirectory(o.Name, o.Fabric))
+	controlplaneCert, err := bootstrap.ReadCertificates(config.ControlplaneDirectory(o.Name, o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}
 
-	dataplaneCert, err := bootstrap.ReadCertificates(config.DataplaneDirectory(o.Name, o.Fabric))
+	dataplaneCert, err := bootstrap.ReadCertificates(config.DataplaneDirectory(o.Name, o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}
 
-	gwctlCert, err := bootstrap.ReadCertificates(config.GWCTLDirectory(o.Name, o.Fabric))
+	gwctlCert, err := bootstrap.ReadCertificates(config.GWCTLDirectory(o.Name, o.Fabric, o.Path))
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterlink/config/config.go
+++ b/cmd/clusterlink/config/config.go
@@ -51,36 +51,36 @@ const (
 )
 
 // FabricDirectory returns the base path of the fabric.
-func FabricDirectory(name string) string {
-	return filepath.Join(".", name)
+func FabricDirectory(name, path string) string {
+	return filepath.Join(path, name)
 }
 
 // PeerDirectory returns the base path for a specific peer.
-func PeerDirectory(peer, fabric string) string {
-	return filepath.Join(FabricDirectory(fabric), peer)
+func PeerDirectory(peer, fabric, path string) string {
+	return filepath.Join(FabricDirectory(fabric, path), peer)
 }
 
 // ControlplaneDirectory returns the path for a controlplane server.
-func ControlplaneDirectory(peer, fabric string) string {
-	return filepath.Join(PeerDirectory(peer, fabric), ControlplaneDirectoryName)
+func ControlplaneDirectory(peer, fabric, path string) string {
+	return filepath.Join(PeerDirectory(peer, fabric, path), ControlplaneDirectoryName)
 }
 
 // DataplaneDirectory returns the path for a dataplane server.
-func DataplaneDirectory(peer, fabric string) string {
-	return filepath.Join(PeerDirectory(peer, fabric), DataplaneDirectoryName)
+func DataplaneDirectory(peer, fabric, path string) string {
+	return filepath.Join(PeerDirectory(peer, fabric, path), DataplaneDirectoryName)
 }
 
 // GWCTLDirectory returns the path for a gwctl instance.
-func GWCTLDirectory(peer, fabric string) string {
-	return filepath.Join(PeerDirectory(peer, fabric), GWCTLDirectoryName)
+func GWCTLDirectory(peer, fabric, path string) string {
+	return filepath.Join(PeerDirectory(peer, fabric, path), GWCTLDirectoryName)
 }
 
 // FabricCertificate returns the fabric certificate name.
-func FabricCertificate(name string) string {
-	return filepath.Join(FabricDirectory(name), CertificateFileName)
+func FabricCertificate(name, path string) string {
+	return filepath.Join(FabricDirectory(name, path), CertificateFileName)
 }
 
 // FabricKey returns the fabric key name.
-func FabricKey(name string) string {
-	return filepath.Join(FabricDirectory(name), PrivateKeyFileName)
+func FabricKey(name, path string) string {
+	return filepath.Join(FabricDirectory(name, path), PrivateKeyFileName)
 }


### PR DESCRIPTION
Fix the path flags for the ClusterLink CLI.
