### PR TITLE
[website]: add netlify _redirects file

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -49,7 +49,7 @@ header:
     - "**/*.scss"
     - "**/*.svg"
     - "**/*.lock"
-    
+    - "website/layouts/**"
 
   comment: on-failure
 

--- a/website/config.toml
+++ b/website/config.toml
@@ -9,6 +9,7 @@ defaultContentLanguageInSubdir = false
 enableMissingTranslationPlaceholders = true
 
 enableRobotsTXT = true
+disableAliases = true
 
 # Will give values to .Lastmod etc.
 enableGitInfo = false
@@ -83,9 +84,19 @@ description = "ClusterLink documentation"
 
 # Everything below this are Site Params
 
-# Comment out if you don't want the "print entire section" link enabled.
+# output HTML and netlify redirects
 [outputs]
-section = ["HTML"]
+home = ["HTML", "REDIRECTS"]
+
+# rules for generating _redirects from layouts/index.redirects 
+[outputFormats.REDIRECTS]
+mediaType = "text/netlify"
+baseName = "_redirects"
+isPlainText = true
+notAlternative = true
+
+[mediaTypes."text/netlify"]
+delimiter = ""
 
 [params]
 copyright = "The ClusterLink Authors"

--- a/website/layouts/index.redirects
+++ b/website/layouts/index.redirects
@@ -1,0 +1,4 @@
+{{- $latest   := site.Params.latest_stable_version -}}
+/docs                             /docs/{{ $latest }}     301!
+/docs/latest                      /docs/{{ $latest }}
+/docs/latest/*                    /docs/{{ $latest }}/:splat


### PR DESCRIPTION
add automatic generation of netlify formatted _redirects file.

- introduce rules for redirecting `/docs` to `/docs/<latest>` and `/docs/*` to `/docs/latest/*`. 
- set latest based on `last_stable_version` in config.toml


More rules can be added to `layouts/index.redirect`. See issue #532 for more context.

Fixes #532 