### PR TITLE
[website] use default named links

### DIFF
--- a/website/content/en/blog/hello-world/index.md
+++ b/website/content/en/blog/hello-world/index.md
@@ -14,7 +14,7 @@ I’m ClusterLink, and as the new kid on the block, I’d like to
  say hello and introduce myself. I’m just starting out as an open-source
  project trying to find my place in the big, wide world of multicluster
  Kubernetes connectivity. This is my first venture away from
- my [home on GitHub](https://github.com/clusterlink-net/clusterlink).
+ my [home on GitHub][].
 
 My core is centered around three key principles: **Seamlessness**, **Simplicity**,
  and **Security**. I focus on applying these principles to service access across
@@ -71,11 +71,9 @@ First things first, though – I want to make it clear that I’m "work in progr
 
 So, what do you say? Want to give me a try? I promise I won’t disappoint.
  And if you find me useful (which I’m sure you will), there are plenty of
- ways you can help me grow and improve: join the [users' mailing list](https://groups.google.com/g/clusterlink-users),
- [issues or enhancement requests](https://github.com/clusterlink-net/clusterlink/issues),
- provide additional [documentation](https://github.com/clusterlink-net/clusterlink/tree/main/website)
- and [code](https://github.com/clusterlink-net/clusterlink), or make a suggestion.
- The possibilities are endless!
+ ways you can help me grow and improve: join the [users' mailing list][],
+ [issues or enhancement requests][], provide additional [documentation][]
+ and [code][], or make a suggestion. The possibilities are endless!
 
 I can't wait to start on this journey with all of you. Together, we'll make
  the world of Kubernetes a better, safer, and more connected place.
@@ -83,3 +81,9 @@ I can't wait to start on this journey with all of you. Together, we'll make
 
 [^1]: While normal access policies work, the implementation of privileged policy tier
 was ongoing and enabled shortly after the 0.1.0 release - it is currently part of `main` branch.
+
+[home on GitHub]: https://github.com/clusterlink-net/clusterlink
+[users' mailing list]: https://groups.google.com/g/clusterlink-users
+[issues or enhancement requests]: https://github.com/clusterlink-net/clusterlink/issues
+[documentation]: https://github.com/clusterlink-net/clusterlink/tree/main/website
+[code]: https://github.com/clusterlink-net/clusterlink

--- a/website/content/en/docs/main/concepts/fabric.md
+++ b/website/content/en/docs/main/concepts/fabric.md
@@ -4,9 +4,9 @@ description: Defining a ClusterLink fabric
 weight: 10
 ---
 
-The concept of a *Fabric* encapsulates a set of cooperating [peers][concept-peer].
- All peers in a fabric can communicate and may share [services][concept-service]
- between them, with access governed by [policies][concept-policy].
+The concept of a *Fabric* encapsulates a set of cooperating [peers][].
+ All peers in a fabric can communicate and may share [services][]
+ between them, with access governed by [policies][].
  The Fabric acts as a root of trust for peer to peer communications (i.e.,
  it functions as the certificate authority enabling mutual authentication between
  peers).
@@ -26,7 +26,7 @@ Currently, the concept of a Fabric is just that - a concept. It is not represent
 
 The following assume that you have access to the `clusterlink` CLI and one or more
  peers (i.e., clusters) where you'll deploy ClusterLink. The CLI can be downloaded
- from the ClusterLink [releases page on GitHub](https://github.com/clusterlink-net/clusterlink/releases/latest).
+ from the ClusterLink [releases page on GitHub][].
 
 ### Create a new fabric CA
 
@@ -44,10 +44,11 @@ This command will create the CA files `cert.pem` and `key.pem` in a directory na
 ## Related tasks
 
 Once a Fabric has been created and initialized, you can proceed with configuring
- [peers][concept-peer]. For a complete, end to end, use case please refer to the
- [iperf tutorial][tutorial-iperf].
+ [peers][]. For a complete, end to end, use case please refer to the
+ [iperf tutorial][].
 
-[concept-peer]: {{< relref "peers" >}}
-[concept-service]: {{< relref "services" >}}
-[concept-policy]: {{< relref "policies" >}}
-[tutorial-iperf]: {{< relref "../tutorials/iperf" >}}
+[peers]: {{< relref "peers" >}}
+[services]: {{< relref "services" >}}
+[policies]: {{< relref "policies" >}}
+[releases page on GitHub]: https://github.com/clusterlink-net/clusterlink/releases/latest
+[iperf tutorial]: {{< relref "../tutorials/iperf" >}}

--- a/website/content/en/docs/main/concepts/peers.md
+++ b/website/content/en/docs/main/concepts/peers.md
@@ -5,11 +5,11 @@ weight: 20
 ---
 
 A *Peer* represents a location, such as a Kubernetes cluster, participating in a
- [fabric][concept-fabric]. Each peer may host one or more [services][concept-service]
+ [fabric][]. Each peer may host one or more [services][]
  it wishes to share with other peers. A peer is managed by a peer administrator,
  which is responsible for running the ClusterLink control and data planes. The
  administrator will typically deploy the ClusterLink components by configuring
- the [deployment CR][operator-cr]. They may also wish to provide
+ the [deployment CR][]. They may also wish to provide
  (often) coarse-grained access policies in accordance with high level corporate
  policies (e.g., "production peers should only communicate with other production peers").
 
@@ -24,9 +24,9 @@ Once a peer has been added to a fabric, it can communicate with any other peer
 
 The following assume that you have access to the `clusterlink` CLI and one or more
  peers (i.e., clusters) where you'll deploy ClusterLink. The CLI can be downloaded
- from the ClusterLink [releases page on GitHub](https://github.com/clusterlink-net/clusterlink/releases/latest).
- It also assumes that you have access to the [previously created][concept-fabric-new]
- fabric CA files.
+ from the ClusterLink [releases page on GitHub][].
+ It also assumes that you have access to the [previously created fabric][]
+ CA files.
 
 ## Initializing a new peer
 
@@ -130,8 +130,7 @@ After the operator is installed, you can deploy ClusterLink by applying
  Configurations affecting the entire peer, such as the list of known peers, are also maintained
  in the same namespace.
 
-Refer to the [operator documentation][operator-cli-flags] for a description
- of the ClusterLink CR fields.
+Refer to the [operator documentation][] for a description of the ClusterLink CR fields.
 
 ## Add or remove peers
 
@@ -179,13 +178,13 @@ There are two fundamental attributes in the peer CRD: the peer name and the list
  ClusterLink gateway endpoints through which the remote peer's services are available.
  Peer names are unique and must align with the Subject name present in their certificate
  during connection establishment. The name is used by importers in referencing an export
- (see [here][concept-service] for details).
+ (see [services][] for details).
 
 Gateway endpoint would typically be a implemented via a `NodePort` or `LoadBalancer`
  K8s service. A `NodePort` service would typically be used in local deployments
  (e.g., when running in kind clusters during development) and a `LoadBalancer` service
  would be used in cloud based deployments. These can be automatically configured and
- created via the [ClusterLink CR][concept-peer-deploy-via-cr].
+ created via the [ClusterLink CR][].
  The peer's status section includes a `Reachable` condition indicating whether the peer is currently reachable,
  and in case it is not reachable, the last time it was.
 
@@ -197,14 +196,15 @@ Gateway endpoint would typically be a implemented via a `NodePort` or `LoadBalan
 
 Once a peer has been created and initialized with the ClusterLink control and data
  planes as well as one or more remote peers, you can proceed with configuring
- [services][concept-service] and [policies][concept-policy].
- For a complete end to end use case, refer to the [iperf tutorial][tutorial-iperf].
+ [services][] and [policies][].
+ For a complete end to end use case, refer to the [iperf tutorial][].
 
-[concept-fabric]: {{< relref "fabric" >}}
-[concept-fabric-new]: {{< relref "fabric#create-a-new-fabric-ca" >}}
-[concept-service]: {{< relref "services" >}}
-[concept-policy]: {{< relref "policies" >}}
+[fabric]: {{< relref "fabric" >}}
+[previously created fabric]: {{< relref "fabric#create-a-new-fabric-ca" >}}
+[services]: {{< relref "services" >}}
+[policies]: {{< relref "policies" >}}
+[releases page on GitHub]: https://github.com/clusterlink-net/clusterlink/releases/latest
 [operator-cr]: {{< relref "../tasks/operator#deploy-cr-instance" >}}
-[operator-cli-flags]: {{< relref "../tasks/operator#commandline-flags" >}}
-[concept-peer-deploy-via-cr]: {{< relref "peers#deploy-clusterlink-via-the-operator-and-clusterlink-cr" >}}
-[tutorial-iperf]: {{< relref "../tutorials/iperf" >}}
+[operator documentation]: {{< relref "../tasks/operator#commandline-flags" >}}
+[ClusterLink CR]: {{< relref "peers#deploy-clusterlink-via-the-operator-and-clusterlink-cr" >}}
+[iperf tutorial]: {{< relref "../tutorials/iperf" >}}

--- a/website/content/en/docs/main/concepts/policies.md
+++ b/website/content/en/docs/main/concepts/policies.md
@@ -6,17 +6,15 @@ weight: 40
 
 Access policies allow users and administrators fine-grained control over
  which client workloads may access which service. This is an important security
- mechanism for applying [micro-segmentation](https://en.wikipedia.org/wiki/Microsegmentation_(network_security)),
- which is a basic requirement of [zero-trust](https://en.wikipedia.org/wiki/Zero_trust_security_model)
+ mechanism for applying [micro-segmentation][], which is a basic requirement of [zero-trust][]
  systems. Another zero-trust principle, "Deny by default / Allow by exception", is also
  addressed by ClusterLink's access policies: a connection without an explicit policy allowing it,
  will be dropped. Access policies can also be used for enforcing corporate security rules,
  as well as segmenting the fabric into trust zones.
 
 ClusterLink's access policies are based on attributes that are attached to
- [peers][concept-peer], [services][concept-service] and client workloads.
- Each attribute is a key:value pair, similar to how
- [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+ [peers][], [services][] and client workloads.
+ Each attribute is a key:value pair, similar to how [labels][]
  are used in Kubernetes. This approach, called ABAC (Attribute Based Access Control),
  allows referring to a set of entities in a single policy, rather than listing individual
  entity names. Using attributes is safer, more resilient to changes, and easier to
@@ -59,7 +57,7 @@ For a connection to be established, both the ClusterLink gateway on the client
 ## Prerequisites
 
 The following assumes that you have `kubectl` access to two or more clusters where ClusterLink
- has already been [deployed and configured][getting-started-user-setup].
+ has already been [deployed and configured][].
 
 ### Creating access policies
 
@@ -124,8 +122,7 @@ A `WorkloadSetOrSelector` object has two fields; exactly one of them must be spe
 
 - **WorkloadSets** (string array, optional) - an array of predefined sets of workload.
  Currently not supported.
-- **WorkloadSelector** (LabelSelector, optional) - a Kubernetes
- [label selector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#labelselector-v1-meta)
+- **WorkloadSelector** (LabelSelector, optional) - a [Kubernetes label selector][]
  defining a set of client workloads or a set of services, based on their
  attributes. An empty selector matches all workloads/services.
 
@@ -145,8 +142,13 @@ spec:
     - workloadSelector: {}
 ```
 
-More examples are available [here](https://github.com/clusterlink-net/clusterlink/tree/main/pkg/policyengine/examples)
+More examples are available on our repo under [policyengine/examples][].
 
-[concept-peer]: {{< relref "peers" >}}
-[concept-service]: {{< relref "services" >}}
-[getting-started-user-setup]: {{< relref "../getting-started/users#setup" >}}
+[peers]: {{< relref "peers" >}}
+[services]: {{< relref "services" >}}
+[micro-segmentation]: https://en.wikipedia.org/wiki/Microsegmentation_(network_security)
+[zero-trust]: https://en.wikipedia.org/wiki/Zero_trust_security_model
+[labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+[deployed and configured]: {{< relref "../getting-started/users#setup" >}}
+[Kuberenetes label selector]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#labelselector-v1-meta
+[policyengine/examples]: https://github.com/clusterlink-net/clusterlink/tree/main/pkg/policyengine/examples

--- a/website/content/en/docs/main/concepts/services.md
+++ b/website/content/en/docs/main/concepts/services.md
@@ -6,14 +6,13 @@ weight: 30
 
 ClusterLink uses services as the unit of sharing between peers.
  One or more peers can expose an (internal) K8s Service to
- be consumed by other [peers][concept-peer] in the [fabric][concept-fabric].
+ be consumed by other [peers][] in the [fabric][].
  A service is exposed by creating an *Export* CR referencing it in the
  source cluster. Similarly, the exported service can be made accessible to workloads
  in a peer by defining an *Import* CR in the destination cluster[^KEP-1645].
  Thus, service sharing is an explicit operation. Services are not automatically
  shared by peers in the fabric. Note that the exporting cluster must be
- [configured as a peer][concept-peer-management] of the importing
- cluster.
+ [configured as a peer][] of the importing cluster.
 
 {{< notice info >}}
 Services sharing is done on a per namespace basis and does not require cluster wide privileges.
@@ -46,7 +45,7 @@ Orchestration of service sharing is the responsibility of users wishing to
 ## Prerequisites
 
 The following assume that you have `kubectl` access to two or more clusters where ClusterLink
- has already been [deployed and configured][getting-started-user-setup].
+ has already been [deployed and configured][].
 
 ### Exporting a service
 
@@ -96,8 +95,7 @@ Note that exporting a Service does not automatically make is accessible to other
  define at least one [access control policy][concept-policy] that allows
  access in the exporting cluster.
  In addition, users in consuming clusters must still explicitly configure
- [service imports](#importing-a-service) and [policies][concept-policy]
- in their respective namespaces.
+ [service imports][] and [policies][] in their respective namespaces.
 
 {{% expand summary="Example YAML for `kubectl apply -f <export_file>`" %}}
 
@@ -170,8 +168,7 @@ The ImportSpec defines the following fields:
  it to select a random and non-conflicting port, but there may be cases where
  you wish to assume responsibility for port selection (e.g., a-priori define
  local cluster Kubernetes NetworkPolicy object instances). This may result in
- [port conflicts](https://kubernetes.io/docs/concepts/services-networking/service/#avoid-nodeport-collisions)
- as is done for NodePort services.
+ [port conflicts][] as is done for NodePort services.
 - **Sources** (source array, required): references to remote exports providing backends
  for the Import. Each reference names a different export through the combination of:
   - *Peer* (string, required): name of ClusterLink peer where the export is defined.
@@ -188,7 +185,7 @@ The ImportSpec defines the following fields:
 
 As with exports, importing a service does not automatically make it accessible by
  workloads, but only enables *potential* access. To complete service sharing,
- you must define at least one [access control policy][concept-policy] that
+ you must define at least one [access control policy][] that
  allows access in the importing cluster. To grant access, a connection must be
  evaluated to "allow" by both egress (importing cluster) and ingress (exporting
  cluster) policies.
@@ -214,22 +211,26 @@ spec:
 ## Related tasks
 
 Once a service is exported and imported by one or more clusters, you should
- configure [polices][concept-policy] governing its access.
- For a complete end to end use case, refer to [iperf tutorial][tutorial-iperf].
+ configure [polices][] governing its access.
+ For a complete end to end use case, refer to [iperf tutorial][].
 
 [^KEP-1645]: While using similar terminology as the Kubernetes Multicluster Service
- enhancement proposal ([MCS KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api)),
- the ClusterLink implementation intentionally differs from and is not compliant with the
- KEP (e.g., there is no `ClusterSet` and "name sameness" assumption).
+ enhancement proposal ([MCS KEP][]), the ClusterLink implementation intentionally
+ differs from and is not compliant with the KEP (e.g., there is no `ClusterSet`
+ and "name sameness" assumption).
 
 [^multiport]: ClusterLink intentionally does not expose all service ports, as
  typically only a small subset in a multi-port service is meant to be user
  accessible, and other ports are service internal (e.g., ports used for internal
  service coordination and replication).
 
-[concept-fabric]: {{< relref "fabric" >}}
-[concept-peer]: {{< relref "peers" >}}
-[concept-peer-management]: {{< relref "peers#add-or-remove-peers" >}}
-[concept-policy]: {{< relref "policies" >}}
-[tutorial-iperf]: {{< relref "../tutorials/iperf" >}}
-[getting-started-user-setup]: {{< relref "../getting-started/users#setup" >}}
+[fabric]: {{< relref "fabric" >}}
+[peers]: {{< relref "peers" >}}
+[configured as a peer]: {{< relref "peers#add-or-remove-peers" >}}
+[policies]: {{< relref "policies" >}}
+[service imports]: #importing-a-service
+[port conflicts]: https://kubernetes.io/docs/concepts/services-networking/service/#avoid-nodeport-collisions
+[access control policy]: {{< relref "policies" >}}
+[iperf tutorial]: {{< relref "../tutorials/iperf" >}}
+[deployed and configured]: {{< relref "../getting-started/users#setup" >}}
+[MCS KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api

--- a/website/content/en/docs/main/doc-contribution/_index.md
+++ b/website/content/en/docs/main/doc-contribution/_index.md
@@ -4,9 +4,8 @@ weight: 60
 description: How to contribute to the website
 ---
 
-We use [Hugo](https://gohugo.io/) to format and generate our [website](https://clusterlink.net),
- the [Docsy](https://github.com/google/docsy) theme for styling and site structure,
- and [Netlify](https://www.netlify.com/) to manage the deployment of the site.
+We use [Hugo][] to format and generate our [website][], the [Docsy][] theme
+ for styling and site structure, and [Netlify][] to manage the deployment of the site.
  Hugo is an open-source static site generator that provides us with templates,
  content organization in a standard directory structure, and a website generation
  engine. You write the pages in Markdown (or HTML if you want), and Hugo wraps
@@ -14,8 +13,7 @@ We use [Hugo](https://gohugo.io/) to format and generate our [website](https://c
 
 All submissions, including submissions by project members, require review. We
  use GitHub pull requests for this purpose. Consult
- [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
- information on using pull requests.
+ [GitHub Help][] for more information on using pull requests.
 
 ## Quick start with Netlify
 
@@ -23,7 +21,7 @@ Here's a quick guide to updating the docs. It assumes you're familiar with the
  GitHub workflow and you're happy to use the automated preview of your website
  updates:
 
-1. Fork the [ClusterLink repo](https://github.com/clusterlink-net/clusterlink) on GitHub.
+1. Fork the [ClusterLink repo][] on GitHub.
 1. The documentation site is under the `website` directory.
 1. Make your changes and send a pull request (PR).
 1. If you're not yet ready for a review, add "WIP" to the PR name to indicate
@@ -49,8 +47,8 @@ If you've just spotted something you'd like to change while using the docs, Docs
  get one - click **Fork this repository and propose changes** or **Update your Fork** to
  get an up-to-date version of the project to edit. The appropriate page in your fork is
  displayed in edit mode.
-1. Follow the rest of the [Quick start with Netlify](#quick-start-with-netlify) process
- above to make, preview, and propose your changes.
+1. Follow the rest of the [Quick start with Netlify][] process above to make, preview,
+ and propose your changes.
 
 ## Previewing your changes locally
 
@@ -58,7 +56,7 @@ If you want to run your own local Hugo server to preview your changes as you wor
 
 <!-- TODO should add a dedicated getting-started for website authoring -->
 
-1. Follow the instructions in [Getting started][getting-started-documentation] to install Hugo
+1. Follow the instructions in [Getting started][] to install Hugo
  and any other tools you need. You'll need at least **Hugo version 0.110** (we recommend
  using the most recent available version), and it must be the **extended** version,
  which supports SCSS.
@@ -71,17 +69,28 @@ If you want to run your own local Hugo server to preview your changes as you wor
 ## Creating an issue
 
 If you've found a problem in the docs, but you're not sure how to fix it yourself,
- please create an issue in the [ClusterLink repo](https://github.com/clusterlink-net/clusterlink/issues).
+ please create an [issue][] in the ClusterLink repo.
  You can also create an issue about a specific page by clicking the **Create Issue**
  button in the top right hand corner of the page.
 
 ## Useful resources
 
-* [Docsy user guide](https://www.docsy.dev/docs/): All about Docsy, including how it
- manages navigation, look and feel, and multi-language support.
-* [Hugo documentation](https://gohugo.io/documentation/): Comprehensive reference for Hugo.
-* [Github Hello World!](https://guides.github.com/activities/hello-world/): A basic
- introduction to GitHub concepts and workflow.
+* [Docsy user guide][]: All about Docsy, including how it manages navigation,
+ look and feel, and multi-language support.
+* [Hugo documentation][]: Comprehensive reference for Hugo.
+* [Github Hello World!][]: A basic introduction to GitHub concepts and workflow.
 
-[getting-started-documentation]: ../getting-started/
 <!-- a documentation specific getting started guide is missing. Tracked in issue #526 -->
+
+[Hugo]: https://gohugo.io/
+[website]: https://clusterlink.net
+[Docsy]: https://github.com/google/docsy
+[Netlify]: https://www.netlify.com/
+[GitHub Help]: https://help.github.com/articles/about-pull-requests/
+[Quick start with Netlify]: #quick-start-with-netlify
+[Getting started]: ../getting-started/
+[ClusterLink repo]: https://github.com/clusterlink-net/clusterlink
+[issue]: https://github.com/clusterlink-net/clusterlink/issues
+[Docsy user guide]: https://www.docsy.dev/docs/
+[Hugo documentation]: https://gohugo.io/documentation/
+[Github Hello World!]: https://guides.github.com/activities/hello-world/

--- a/website/content/en/docs/main/getting-started/_index.md
+++ b/website/content/en/docs/main/getting-started/_index.md
@@ -4,12 +4,11 @@ description: Getting started guides for users and developers
 weight: 20
 ---
 
-The following provide quick start guides for [users][user-getting-started] and
- [developers][dev-getting-started].
+The following provide quick start guides for [users][] and [developers][].
 
 If you're a content author, wishing to contribute additional documentation or guides,
- please refer to the [contribution guidelines][doc-contribution].
+ please refer to the [contribution guidelines][].
 
-[user-getting-started]: {{< relref "users" >}}
-[dev-getting-started]: {{< relref "developers" >}}
-[doc-contribution]: ../doc-contribution/
+[users]: {{< relref "users" >}}
+[developers]: {{< relref "developers" >}}
+[contribution guidelines]: ../doc-contribution/

--- a/website/content/en/docs/main/getting-started/developers.md
+++ b/website/content/en/docs/main/getting-started/developers.md
@@ -11,13 +11,13 @@ This guide provides a quick start for developers wishing to contribute to Cluste
 Here are the key steps for setting up your developer environment, making a change and testing it:
 
 1. Install required tools (you can either do this manually or use the project's
- [devcontainer specification](https://github.com/clusterlink-net/clusterlink/tree/main/.devcontainer/dev))
-    - [Go](https://go.dev/doc/install) version 1.20 or higher.
-    - [Git](https://git-scm.com/downloads) command line.
-    - We recommend using a [local development environment](https://kubernetes.io/docs/tasks/tools/)
-      such as kind/kubectl for local development and integration testing.
+ [devcontainer specification][])
+    - [Go][] version 1.20 or higher.
+    - [Git][] command line.
+    - We recommend using a [local development environment][]  such as kind/kubectl for
+      local development and integration testing.
     - Additional development packages, such as `goimports` and `golangci-lint`. See the full list in
-      [post-create.sh](https://github.com/clusterlink-net/clusterlink/blob/main/.devcontainer/dev/post-create.sh).
+      [post-create.sh][].
 1. Clone our repository with `git clone git@github.com:clusterlink-net/clusterlink.git`.
 1. Run `make test-prereqs` and install any missing required development tools.
 1. Run `make build` to ensure the code builds as expected. This will pull in all needed
@@ -26,8 +26,8 @@ Here are the key steps for setting up your developer environment, making a chang
 ## Making code changes
 
 - If you are planning on contributing back to the project, please carefully read the
- [contribution guide](https://github.com/clusterlink-net/clusterlink/blob/main/CONTRIBUTING.md).
-- We follow [GitHub's Standard Fork & Pull Request Workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
+ [contribution guide][].
+- We follow [GitHub's Standard Fork & Pull Request Workflow][].
 
 All contributed code should should pass precommit checks such as linting and tests. These
  are run automatically as part of the CI process on every pull request. You may wish to
@@ -57,7 +57,7 @@ All pull requests undergo automated testing before being merged. This includes, 
 
 ClusterLink releases, including container images and binaries, are built based
  on version tags in github. Applying a tag that's prefixed by `-v` will automatically
- trigger a new release through the github [release](https://github.com/clusterlink-net/clusterlink/blob/main/.github/workflows/release.yml) action.
+ trigger a new release through the github [release][] action.
 
 To aid in auto-generation of changelog from commits, please kindly mark all PR's
  with one or more of the following labels:
@@ -70,3 +70,12 @@ To aid in auto-generation of changelog from commits, please kindly mark all PR's
 - `breaking-change`: PR introduces a breaking change in user facing aspects
  (e.g., API or CLI). This label may be used in addition to other labels (e.g.,
  `bugfix` or `enhancement`).
+
+[devcontainer specification]: https://github.com/clusterlink-net/clusterlink/tree/main/.devcontainer/dev
+[Go]: https://go.dev/doc/install
+[Git]: https://git-scm.com/downloads
+[local development environment]: https://kubernetes.io/docs/tasks/tools/
+[post-create.sh]: https://github.com/clusterlink-net/clusterlink/blob/main/.devcontainer/dev/post-create.sh
+[contribution guide]: https://github.com/clusterlink-net/clusterlink/blob/main/CONTRIBUTING.md
+[GitHub's Standard Fork & Pull Request Workflow]: https://gist.github.com/Chaser324/ce0505fbed06b947d962
+[release]: https://github.com/clusterlink-net/clusterlink/blob/main/.github/workflows/release.yml

--- a/website/content/en/docs/main/getting-started/users.md
+++ b/website/content/en/docs/main/getting-started/users.md
@@ -9,7 +9,7 @@ This guide will give you a quick start on installing and setting up the ClusterL
 ## Prerequisites
 
 Before you start, you must have access to a Kubernetes cluster.
-For example, you can set up a local environment using the [kind](https://kind.sigs.k8s.io/) project.
+For example, you can set up a local environment using [kind][].
 
 ## Installation
 
@@ -67,15 +67,15 @@ To set up ClusterLink on a Kubernetes cluster, follow these steps:
     If they were not, use the flag `--path <path>` for pointing to the working directory
     that was used in the previous command.
     The `--fabric` option is optional, and by default, "default_fabric" will be used.
-    For more details and deployment configuration see [ClusterLink deployment operator][operator].
+    For more details and deployment configuration see [ClusterLink deployment operator][].
 {{< notice note >}}
 To deploy ClusterLink on another cluster, repeat steps 2-3 in a console with access to the cluster.
 {{< /notice >}}
 
 ## Try it out
 
-Check out the [ClusterLink Tutorials][tutorials] for setting up
-multi-cluster connectivity for applications using two or more clusters.
+Check out the [ClusterLink Tutorials][] for setting up multi-cluster connectivity
+ for applications using two or more clusters.
 
 ## Uninstall ClusterLink
 
@@ -103,5 +103,6 @@ This command  using the current `kubectl` context.
    rm `which clusterlink`
    ```
 
-[operator]: {{< relref "../tasks/operator" >}}
-[tutorials]: ../tutorials/
+[kind]: https://kind.sigs.k8s.io/)
+[ClusterLink deployment operator]: {{< relref "../tasks/operator" >}}
+[ClusterLink tutorials]: ../tutorials/

--- a/website/content/en/docs/main/overview/_index.md
+++ b/website/content/en/docs/main/overview/_index.md
@@ -44,8 +44,8 @@ The distributed control plane and the fine grained connection establishment cont
 
 ## Where should I go next?
 
-* [Getting Started][getting-started]: Get started with ClusterLink.
-* [Tutorials][tutorials]: Check out some examples and step-by-step instructions for different use cases.
+* [Getting Started][]: Get started with ClusterLink.
+* [Tutorials][]: Check out some examples and step-by-step instructions for different use cases.
 
-[getting-started]: ../getting-started/
-[tutorials]: ../tutorials/
+[Getting Started]: ../getting-started/
+[Tutorials]: ../tutorials/

--- a/website/content/en/docs/main/tasks/operator.md
+++ b/website/content/en/docs/main/tasks/operator.md
@@ -8,7 +8,7 @@ The ClusterLink deployment operator allows easy deployment of ClusterLink to a K
 The preferred deployment approach involves utilizing the ClusterLink CLI,
 which automatically deploys both the ClusterLink operator and ClusterLink components.
 However, it's important to note that ClusterLink deployment necessitates peer certificates for proper functioning.
-Detailed instructions for creating these peer certificates can be found in the [user guide][getting-started-user-setup].
+Detailed instructions for creating these peer certificates can be found in the [user guide][].
 
 ## The common use-case
 
@@ -39,10 +39,10 @@ clusterlink deploy peer --name <peer_name> --fabric <fabric_name> --ingress=Node
 The Kind environment doesn't allocate an external IP to the `LoadBalancer` service by default.
 In this case, we will use a `NodePort` service to establish multi-cluster connectivity using ClusterLink.
 Alternatively, you can install MetalLB to add a Load Balancer implementation to the Kind cluster. See instructions
-[here](https://kind.sigs.k8s.io/docs/user/loadbalancer/).
+[here][].
 The port flag is optional, and by default, ClusterLink will use any allocated NodePort that the Kind cluster provides.
 However, it is more convenient to use a fixed setting NodePort for peer configuration, as demonstrated in the
-[ClusterLink Tutorials][tutorials].
+[ClusterLink Tutorials][].
 
 ## Deployment of specific version
 
@@ -64,7 +64,7 @@ The deployment process can be split into two steps:
     clusterlink deploy peer ---name <peer_name> --fabric <fabric_name> --start operator
     ```
 
-    The `start` flag will deploy only the ClusterLink operator and the certificate's secrets as described in the [common use case][cloud-install] above.
+    The `start` flag will deploy only the ClusterLink operator and the certificate's secrets as described in the [common use case][] above.
 
 2. {{< anchor deploy-cr-instance >}} Deploy a ClusterLink instance custom resource object:
 
@@ -165,6 +165,7 @@ To deploy the ClusterLink without using the CLI, follow the instructions below:
     EOF
     ```
 
-[getting-started-user-setup]: {{< relref "../getting-started/users#setup" >}}
-[tutorials]: ../tutorials/
-[cloud-install]: #the-common-use-case
+[user guide]: {{< relref "../getting-started/users#setup" >}}
+[ClusterLink tutorials]: ../tutorials/
+[here]: https://kind.sigs.k8s.io/docs/user/loadbalancer/
+[common use case]: #the-common-use-case

--- a/website/content/en/docs/main/tutorials/bookinfo/index.md
+++ b/website/content/en/docs/main/tutorials/bookinfo/index.md
@@ -4,10 +4,10 @@ description: Running BookInfo application with different policies.
 ---
 
 
-The tutorial sets up [Istio BookInfo application][Istio-BookInfo] in different clusters.
+The tutorial sets up [Istio BookInfo application][] in different clusters.
 The tutorial demonstrates the use of AccessPolicy and PrivilegedAccessPolicy custom resources.
 The tutorial shows different load-balancing policies like: random, round-robin or static destination.
-For more details, see the [policies documentation][concept-policy].
+For more details, see the [policies documentation][].
 This test creates three kind clusters:
 
 * Two Product-Page microservice (application frontend) and details microservice run on the first cluster.
@@ -38,7 +38,7 @@ In this tutorial we set up a local environment using [kind][].
 
 To setup three kind clusters:
 
-1. Install kind using [kind installation guide][kind-installation-guide].
+1. Install kind using [kind installation guide][].
 2. Create a directory for all the tutorial files:
 
     ```sh
@@ -255,7 +255,7 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-For more details regarding policy configuration, see [policies documentation][concept-policy].
+For more details regarding policy configuration, see [policies documentation][].
 
 ## Apply random load-balancing policy
 
@@ -397,7 +397,7 @@ spec:
     ```
 
 <!-- Links list -->
-[Istio-BookInfo]: https://istio.io/latest/docs/examples/bookinfo/
-[concept-policy]: ../../concepts/policies
-[kind-installation-guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[Istio BookInfo application]: https://istio.io/latest/docs/examples/bookinfo/
+[policies documentation]: ../../concepts/policies
+[kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
 [kind]: https://kind.sigs.k8s.io/

--- a/website/content/en/docs/main/tutorials/iperf/index.md
+++ b/website/content/en/docs/main/tutorials/iperf/index.md
@@ -25,13 +25,13 @@ The tutorial uses two kind clusters:
 
 ## Initialize clusters
 
-In this tutorial we set up a local environment using [kind](https://kind.sigs.k8s.io/).
+In this tutorial we set up a local environment using [kind][].
  You can skip this step if you already have access to existing clusters, just be sure to
  set KUBECONFIG accordingly.
 
 To setup two kind clusters:
 
-1. Install kind using [kind installation guide](https://kind.sigs.k8s.io/docs/user/quick-start).
+1. Install kind using [kind installation guide][].
 1. Create a directory for all the tutorial files:
 
     ```sh
@@ -116,7 +116,7 @@ kubectl apply -f $IPERF3_FILES/iperf3-server/iperf3.yaml
     clusterlink create peer-cert --name server
     ```
 
-    For more details regarding fabric and peer see [core concepts][concepts].
+    For more details regarding fabric and peer see [core concepts][].
 
 1. Deploy ClusterLink on each cluster:
 
@@ -387,7 +387,7 @@ spec:
 {{% /tab %}}
 {{< /tabpane >}}
 
-For more details regarding policy configuration, see [here][concept-policy].
+For more details regarding policy configuration, see [policies][] documentation.
 
 ## Test service connectivity
 
@@ -460,5 +460,7 @@ iperf Done.
     unset KUBECONFIG IPERF3_FILES
     ```
 
-[concepts]: ../../concepts/
-[concept-policy]: ../../concepts/policies
+[kind]: https://kind.sigs.k8s.io/
+[kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[core concepts]: ../../concepts/
+[policies]: ../../concepts/policies


### PR DESCRIPTION
Fixes #527

Using named links on `main` docs and *not* applying to already released documentation versions.