### PR TITLE
[website] Docs/google analytics

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -167,10 +167,10 @@ sidebar_search_disable = true
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = false
+enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-# yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-# no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/clusterlink-net/clusterlink/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/clusterlink-net/clusterlink/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
 # If you want this feature, but occasionally need to remove the Reading time from a single page,

--- a/website/config.toml
+++ b/website/config.toml
@@ -55,7 +55,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-#id = "UA-00000000-0"
+id = "G-6NB92ZTXFC"
 
 # Language configuration
 


### PR DESCRIPTION
Fixes #463.

- Enable google analytics
- Enable feedback events (e.g., to prioritize page views with low useful score)