### PR TITLE
Create support for arm64 architecture for docker images.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
-      with:
-        fetch-tags: true
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -26,12 +24,15 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build images
-      run: make docker-build
-    - name: Tag and push ClusterLink images with tag 'latest'
-      run: make push-image
-    - name: Tag and push ClusterLink images latest with tag ${{ github.ref_name }}
-      run: make push-image IMAGE_VERSION=${{ github.ref_name }}
+    - name: Build binaries for amd64
+      run: make build
+    - name: Build binaries for arm64
+      run: GOARCH=arm64 make build
+    - name: Tag and push ClusterLink images with tag 'latest' and ${{ github.ref_name }}
+      run: |
+        docker buildx create --use --driver docker-container
+        PLATFORMS=linux/amd64,linux/arm64 make push-image
+        PLATFORMS=linux/amd64,linux/arm64 make push-image IMAGE_VERSION=${{ github.ref_name }}
     - name: Build and compress binaries
       run: |
         for pair in "linux:amd64" "linux:arm64" "darwin:amd64" "darwin:arm64"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build binaries for amd64
-      run: make build
+      run: GOARCH=amd64 make build
     - name: Build binaries for arm64
       run: GOARCH=arm64 make build
     - name: Tag and push ClusterLink images with tag 'latest' and ${{ github.ref_name }}

--- a/cmd/cl-controlplane/Dockerfile
+++ b/cmd/cl-controlplane/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.19
 
+# Populated during the build process, for example, with 'arm64' or 'amd64'.
+ARG TARGETARCH
+
 # Copy binary
 RUN mkdir -p /usr/local/bin
-COPY ./bin/cl-controlplane /usr/local/bin/cl-controlplane
+COPY ./bin/$TARGETARCH/cl-controlplane /usr/local/bin/cl-controlplane
 
 # Create directory for private keys
 RUN mkdir -p /etc/ssl/private

--- a/cmd/cl-dataplane/Dockerfile
+++ b/cmd/cl-dataplane/Dockerfile
@@ -1,8 +1,11 @@
 FROM envoyproxy/envoy:v1.30.1
 
+# Populated during the build process, for example, with 'arm64' or 'amd64'.
+ARG TARGETARCH
+
 # Copy binary
 RUN mkdir -p /usr/local/bin
-COPY ./bin/cl-dataplane /usr/local/bin/cl-dataplane
+COPY ./bin/$TARGETARCH/cl-dataplane /usr/local/bin/cl-dataplane
 
 # Create directory for private keys
 RUN mkdir -p /etc/ssl/private

--- a/cmd/cl-go-dataplane/Dockerfile
+++ b/cmd/cl-go-dataplane/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.19
 
+# Populated during the build process, for example, with 'arm64' or 'amd64'.
+ARG TARGETARCH
+
 # Copy binary
 RUN mkdir -p /usr/local/bin
-COPY ./bin/cl-go-dataplane /usr/local/bin/cl-go-dataplane
+COPY ./bin/$TARGETARCH/cl-go-dataplane /usr/local/bin/cl-go-dataplane
 
 # Create directory for private keys
 RUN mkdir -p /etc/ssl/private

--- a/cmd/cl-operator/Dockerfile
+++ b/cmd/cl-operator/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.14
 
+
+
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY  ./bin/cl-operator cl-operator
+ARG TARGETARCH
+COPY  ./bin/$TARGETARCH/cl-operator cl-operator
 USER 65532:65532
 
 ENTRYPOINT ["/cl-operator"]

--- a/demos/iperf3/cloud/test.py
+++ b/demos/iperf3/cloud/test.py
@@ -23,11 +23,11 @@ from demos.utils.k8s import  getPodNameIp
 from demos.utils.cloud import Cluster
 from demos.iperf3.test import iperf3Test
 
-cl1gcp = Cluster(name="peer1", zone = "us-west1-b", platform = "gcp")
+cl1gcp = Cluster(name="peer1", zone = "us-central1-b", platform = "gcp")
 cl1aws = Cluster(name="peer1", zone = "us-west-2",  platform = "aws")
 cl1ibm = Cluster(name="peer1", zone = "dal10",      platform = "ibm")
 
-cl2gcp = Cluster(name="peer2", zone = "us-west1-b", platform = "gcp")
+cl2gcp = Cluster(name="peer2", zone = "us-central1-b", platform = "gcp")
 cl2aws = Cluster(name="peer2", zone = "us-west-1",  platform = "aws")
 cl2ibm = Cluster(name="peer2", zone = "dal10",      platform = "ibm")
 

--- a/demos/iperf3/testdata/manifests/iperf3-client/iperf3-client.yaml
+++ b/demos/iperf3/testdata/manifests/iperf3-client/iperf3-client.yaml
@@ -1,5 +1,5 @@
 ################################################################
-#Name:  iperf3_client 
+#Name:  iperf3_client
 #Desc: YAML file for creating iperf3 client to send test traffic.
 ################################################################
 apiVersion: apps/v1
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: iperf3-client
         #image: networkstatic/iperf3
-        image: mlabbe/iperf3
+        image: taoyou/iperf3-alpine
         imagePullPolicy: IfNotPresent
         command: ['/bin/sh', '-c', 'sleep infinity']
         # To benchmark manually: kubectl exec iperf3-client-jlfxq -- /bin/sh -c 'iperf3 -c iperf3-server'

--- a/demos/iperf3/testdata/manifests/iperf3-client/iperf3-client2.yaml
+++ b/demos/iperf3/testdata/manifests/iperf3-client/iperf3-client2.yaml
@@ -1,5 +1,5 @@
 ################################################################
-#Name:  iperf3_client 
+#Name:  iperf3_client
 #Desc: YAML file for creating iperf3 client to send test traffic.
 ################################################################
 apiVersion: apps/v1
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: iperf3-client2
         #image: networkstatic/iperf3
-        image: mlabbe/iperf3
+        image: taoyou/iperf3-alpine
         imagePullPolicy: IfNotPresent
         command: ['/bin/sh', '-c', 'sleep infinity']
         # To benchmark manually: kubectl exec iperf3-client2-jlfxq -- /bin/sh -c 'iperf3 -c iperf3-server'

--- a/demos/iperf3/testdata/manifests/iperf3-server/iperf3.yaml
+++ b/demos/iperf3/testdata/manifests/iperf3-server/iperf3.yaml
@@ -1,5 +1,5 @@
 ################################################################
-#Name:  iperf3 
+#Name:  iperf3
 #Desc: YAML file for creating iperf3 server for testing.
 ################################################################
 apiVersion: apps/v1
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: iperf3-server
         #image: networkstatic/iperf3
-        image: mlabbe/iperf3
+        image: taoyou/iperf3-alpine
         imagePullPolicy: IfNotPresent
         args: ['-s', '-p', '5000']
         # ports:


### PR DESCRIPTION
Create support for arm64 architecture for docker images:
1) Update the GitHub action.
2) Update the makefile to compile images according to the architecture
3) Update the docker file to use the correct binary file.
4) Update the push image command to use the --platform flag for multi-architecture Docker image compilation.
5) Update the iperf3 demo to support arm64 architecture.