### PR TITLE
bootstrap/cert: Add an option to read only the CA certificate

### DIFF
--- a/cmd/clusterlink/cmd/deploy/deploy_peer.go
+++ b/cmd/clusterlink/cmd/deploy/deploy_peer.go
@@ -157,14 +157,14 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 	// Read certificates
-	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path))
+	fabricCert, err := bootstrap.ReadCACertificates(config.FabricDirectory(o.Fabric, o.Path))
 	if err != nil {
-		return err
+		return fmt.Errorf("fail to read fabric CA certificate %w", err)
 	}
 
 	peerCertificate, err := bootstrap.ReadCertificates(config.PeerDirectory(o.Name, o.Fabric, o.Path))
 	if err != nil {
-		return err
+		return fmt.Errorf("fail to read peer certificates %w", err)
 	}
 
 	controlplaneCert, err := bootstrap.ReadCertificates(config.ControlplaneDirectory(o.Name, o.Fabric, o.Path))

--- a/pkg/bootstrap/cert.go
+++ b/pkg/bootstrap/cert.go
@@ -146,3 +146,19 @@ func ReadCertificates(dir string) (*Certificate, error) {
 
 	return cert, nil
 }
+
+// ReadCACertificates read CA certificate from folder.
+func ReadCACertificates(dir string) (*Certificate, error) {
+	// Read certificate
+	rawCert, err := os.ReadFile(filepath.Join(dir, config.CertificateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := CertificateFromRaw(rawCert, EmptyCertificate)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}


### PR DESCRIPTION
Allow to the  `deploy peer` command to read only the ca certificate for clusterlink deployment.