### PR TITLE
clusterlink deploy peer: Remove CA private keys requirement

### DIFF
--- a/cmd/clusterlink/cmd/create/create_peer.go
+++ b/cmd/clusterlink/cmd/create/create_peer.go
@@ -123,7 +123,7 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 
-	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path))
+	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path), true)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterlink/cmd/deploy/deploy_peer.go
+++ b/cmd/clusterlink/cmd/deploy/deploy_peer.go
@@ -157,27 +157,32 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 	// Read certificates
-	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path))
+	fabricCert, err := bootstrap.ReadCertificates(
+		config.FabricDirectory(o.Fabric, o.Path), false)
 	if err != nil {
 		return err
 	}
 
-	peerCertificate, err := bootstrap.ReadCertificates(config.PeerDirectory(o.Name, o.Fabric, o.Path))
+	peerCertificate, err := bootstrap.ReadCertificates(
+		config.PeerDirectory(o.Name, o.Fabric, o.Path), false)
 	if err != nil {
 		return err
 	}
 
-	controlplaneCert, err := bootstrap.ReadCertificates(config.ControlplaneDirectory(o.Name, o.Fabric, o.Path))
+	controlplaneCert, err := bootstrap.ReadCertificates(
+		config.ControlplaneDirectory(o.Name, o.Fabric, o.Path), true)
 	if err != nil {
 		return err
 	}
 
-	dataplaneCert, err := bootstrap.ReadCertificates(config.DataplaneDirectory(o.Name, o.Fabric, o.Path))
+	dataplaneCert, err := bootstrap.ReadCertificates(
+		config.DataplaneDirectory(o.Name, o.Fabric, o.Path), true)
 	if err != nil {
 		return err
 	}
 
-	gwctlCert, err := bootstrap.ReadCertificates(config.GWCTLDirectory(o.Name, o.Fabric, o.Path))
+	gwctlCert, err := bootstrap.ReadCertificates(
+		config.GWCTLDirectory(o.Name, o.Fabric, o.Path), true)
 	if err != nil {
 		return err
 	}

--- a/pkg/bootstrap/cert.go
+++ b/pkg/bootstrap/cert.go
@@ -126,17 +126,20 @@ func CertificateFromRaw(rawCert, rawKey []byte) (*Certificate, error) {
 }
 
 // ReadCertificates read certificate and key from folder.
-func ReadCertificates(dir string) (*Certificate, error) {
+func ReadCertificates(dir string, withKey bool) (*Certificate, error) {
 	// Read certificate
 	rawCert, err := os.ReadFile(filepath.Join(dir, config.CertificateFileName))
 	if err != nil {
 		return nil, err
 	}
 
-	// Read key
-	rawFabricKey, err := os.ReadFile(filepath.Join(dir, config.PrivateKeyFileName))
-	if err != nil {
-		return nil, err
+	var rawFabricKey []byte
+	if withKey {
+		// Read key
+		rawFabricKey, err = os.ReadFile(filepath.Join(dir, config.PrivateKeyFileName))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	cert, err := CertificateFromRaw(rawCert, rawFabricKey)

--- a/pkg/bootstrap/crypt.go
+++ b/pkg/bootstrap/crypt.go
@@ -146,17 +146,7 @@ func createCertificate(config *certificateConfig) (*certificate, error) {
 
 // certificateFromRaw initializes a certificate from raw data.
 func certificateFromRaw(certPEM, keyPEM []byte) (*certificate, error) {
-	block, _ := pem.Decode(keyPEM)
-	if block == nil {
-		return nil, fmt.Errorf("key is not in PEM format")
-	}
-
-	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ = pem.Decode(certPEM)
+	block, _ := pem.Decode(certPEM)
 	if block == nil {
 		return nil, fmt.Errorf("certificate is not in PEM format")
 	}
@@ -164,6 +154,19 @@ func certificateFromRaw(certPEM, keyPEM []byte) (*certificate, error) {
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return nil, err
+	}
+
+	var key *rsa.PrivateKey
+	if keyPEM != nil {
+		block, _ := pem.Decode(keyPEM)
+		if block == nil {
+			return nil, fmt.Errorf("key is not in PEM format")
+		}
+
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &certificate{


### PR DESCRIPTION
This PR fixes the clusterlink deploy peer command which unnecessarily required reading the fabric and peer private keys.

Fixes #565