### PR TITLE
Update peers.md

### DIFF
--- a/website/content/en/docs/v0.2/concepts/peers.md
+++ b/website/content/en/docs/v0.2/concepts/peers.md
@@ -6,23 +6,23 @@ weight: 20
 
 A *Peer* represents a location, such as a Kubernetes cluster, participating in a
  [fabric][concept-fabric]. Each peer may host one or more [services][concept-service]
- it wishes to share with other peers. A peer is managed by a peer administrator,
+ that it wishes to share with other peers. A peer is managed by a peer administrator,
  which is responsible for running the ClusterLink control and data planes. The
  administrator will typically deploy the ClusterLink components by configuring
- the [deployment CR][operator-cr]. They may also wish to provide
- (often) coarse-grained access policies in accordance with high level corporate
+ the [deployment Custom Resource (CR)][operator-cr]. The administrator may also wish
+ to provide coarse-grained access policies (and often do) in accordance with high level corporate
  policies (e.g., "production peers should only communicate with other production peers").
 
 Once a peer has been added to a fabric, it can communicate with any other peer
  belonging to it. All configuration relating to service sharing (e.g., the exporting
  and importing of services, and the setting of fine grained application policies) can be
  done with lowered privileges (e.g., by users, such as application owners). Remote peers are
- represented by the Peer Custom Resource Definition (CRD). Each Peer CR instance
+ represented by peer Custom Resource Definition (CRDs). Each Peer CR instance
  defines a remote cluster and the network endpoints of its ClusterLink gateways.
 
 ## Prerequisites
 
-The following assume that you have access to the `clusterlink` CLI and one or more
+The following sections assume that you have access to the ClusterLink CLI and one or more
  peers (i.e., clusters) where you'll deploy ClusterLink. The CLI can be downloaded
  from the ClusterLink [releases page on GitHub](https://github.com/clusterlink-net/clusterlink/releases/latest).
  It also assumes that you have access to the [previously created][concept-fabric-new]
@@ -37,7 +37,7 @@ Creating a new peer is a **fabric administrator** level operation and should be 
 
 ### Create a new peer certificate
 
-To create a new peer certificate belonging to a fabric, confirm that the fabric CA files
+To create a new peer certificate belonging to a fabric, confirm that the fabric Certificate Authority (CA) files
  are available in the current working directory, and then execute the following CLI command:
 
 ```sh
@@ -179,9 +179,9 @@ There are two fundamental attributes in the peer CRD: the peer name and the list
  ClusterLink gateway endpoints through which the remote peer's services are available.
  Peer names are unique and must align with the Subject name present in their certificate
  during connection establishment. The name is used by importers in referencing an export
- (see [here][concept-service] for details).
+ (see [Services][concept-service] for details).
 
-Gateway endpoint would typically be a implemented via a `NodePort` or `LoadBalancer`
+Gateway endpoint would typically be implemented via a `NodePort` or `LoadBalancer`
  K8s service. A `NodePort` service would typically be used in local deployments
  (e.g., when running in kind clusters during development) and a `LoadBalancer` service
  would be used in cloud based deployments. These can be automatically configured and
@@ -198,7 +198,7 @@ Gateway endpoint would typically be a implemented via a `NodePort` or `LoadBalan
 Once a peer has been created and initialized with the ClusterLink control and data
  planes as well as one or more remote peers, you can proceed with configuring
  [services][concept-service] and [policies][concept-policy].
- For a complete end to end use case, refer to the [iperf tutorial][tutorial-iperf].
+ For a complete end-to-end use case, refer to the [iperf tutorial][tutorial-iperf].
 
 [concept-fabric]: {{< relref "fabric" >}}
 [concept-fabric-new]: {{< relref "fabric#create-a-new-fabric-ca" >}}


### PR DESCRIPTION
Changed a few minor things including hyphens, articles, abbreviations, fonts, subject/verb agreement, made links descriptive, etc. --

Here are a few other comments that I didn't implement because someone needs to think about them:

	Initializing a new peer:
•	Under info (in orange) – this sentence doesn’t make sense? “You will need the CA certificate (but not the CA private key) and the peer certificate and private in the next step.” Did you mean private key, the second time it’s mentioned? Certificate and private are mentioned twice and seem contradictory or redundant? Could we either take out this sentence or clarify what it meant? •	When I read this ” They can be provided out of band (e.g., over email) to the peer administrator.” it comes to mind that I would caution against sending something that is supposed to be private over email. What is the best practice? Perhaps give an explanation? 	Deploy ClusterLink to a new peer:This sentence is confusing: “Before proceeding, ensure that the CA certificate (the CA private key is not needed), and the peer certificate and key files which were created in the previous step are in the current working directory.” Reason for the confusion: No need for a private key, but yes need for key files? Public keys? If so is the word “public” worth specifying? 	Add or Remove Peers:
•	Again “out of band” use of email communication encouraged, this time a future way of handling it hinted at, consider again if this is really what you want to advise for now.