### PR TITLE
Disable gomoddirective linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,6 @@ linters:
     - godot
     - gofumpt
     - goimports
-    - gomoddirectives
     - gosec
     - gosimple
     - govet


### PR DESCRIPTION
gomoddirectives fails with:
- invalid go version '1.22.0': must match format 1.23
- unknown directive: toolchain

Both are added with Go 1.22 and above. Disabling linter as there's no fix in upstream