### PR TITLE
Adjust headings to be consistent

### DIFF
--- a/website/content/en/docs/main/concepts/_index.md
+++ b/website/content/en/docs/main/concepts/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Core Concepts
-description: Core Concepts of the ClusterLink system.
+description: Core Concepts of the ClusterLink system
 weight: 30
 ---

--- a/website/content/en/docs/main/tasks/_index.md
+++ b/website/content/en/docs/main/tasks/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Tasks
-description: How to do single specific targeted activities with ClusterLink.
+description: How to do single specific targeted activities with ClusterLink
 weight: 35
 ---

--- a/website/content/en/docs/main/tasks/operator.md
+++ b/website/content/en/docs/main/tasks/operator.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment Operator
-description: Usage and configuration of the ClusterLink deployment operator.
+description: Usage and configuration of the ClusterLink deployment operator
 weight: 50
 ---
 

--- a/website/content/en/docs/main/tutorials/bookinfo/index.md
+++ b/website/content/en/docs/main/tutorials/bookinfo/index.md
@@ -1,6 +1,6 @@
 ---
 title: BookInfo
-description: Running BookInfo application with different policies.
+description: Running BookInfo application with different policies
 ---
 
 

--- a/website/content/en/docs/main/tutorials/iperf/index.md
+++ b/website/content/en/docs/main/tutorials/iperf/index.md
@@ -1,6 +1,6 @@
 ---
 title: iPerf3
-description: Running basic connectivity between iPerf3 applications across two sites using ClusterLink.
+description: Running basic connectivity between iPerf3 applications across two sites using ClusterLink
 ---
 
 In this tutorial we'll establish iPerf3 connectivity between two kind cluster using ClusterLink.


### PR DESCRIPTION
Some of the pages have a period at the heading describing what is on the page, but most don't. This change removes the periods to make them consistent with the rest of the site.