### PR TITLE
Update clusterlink.py

### DIFF
--- a/demos/utils/clusterlink.py
+++ b/demos/utils/clusterlink.py
@@ -52,7 +52,7 @@ class CRDObject:
         except Exception as e:
             print(f"Error deleting {kind} '{name}': {e}")
 
-# Imports Peers contains all the commands for managing peer CRD.
+# Peers class contains all the commands for managing peer CRD.
 class Peers(CRDObject):
     def __init__(self, namespace):
         self.namespace=namespace


### PR DESCRIPTION
documentation

It looked like the imports class comment was copied above to peers, as the comment structures were similar, but it was done improperly by accident.

To resolve this, I removed the word "imports" from the peers comment, and added the word "class."