### PR TITLE
CLI: Enhancement for creation of ClusterLink components' certificates

### DIFF
--- a/cmd/clusterlink/cmd/create/create_peer.go
+++ b/cmd/clusterlink/cmd/create/create_peer.go
@@ -59,24 +59,6 @@ func (o *PeerOptions) saveCertificate(cert *bootstrap.Certificate, outDirectory 
 	return os.WriteFile(filepath.Join(outDirectory, config.PrivateKeyFileName), cert.RawKey(), 0o600)
 }
 
-func (o *PeerOptions) createCA() (*bootstrap.Certificate, error) {
-	cert, err := bootstrap.CreateCACertificate()
-	if err != nil {
-		return nil, err
-	}
-
-	outDirectory := config.CADirectory(o.Name, o.Fabric, o.Path)
-	if err := os.Mkdir(outDirectory, 0o755); err != nil {
-		return nil, err
-	}
-
-	if err := o.saveCertificate(cert, outDirectory); err != nil {
-		return nil, err
-	}
-
-	return cert, nil
-}
-
 func (o *PeerOptions) createPeerCert(fabricCert *bootstrap.Certificate) (*bootstrap.Certificate, error) {
 	cert, err := bootstrap.CreatePeerCertificate(o.Name, fabricCert)
 	if err != nil {
@@ -84,42 +66,6 @@ func (o *PeerOptions) createPeerCert(fabricCert *bootstrap.Certificate) (*bootst
 	}
 
 	outDirectory := config.PeerDirectory(o.Name, o.Fabric, o.Path)
-	if err := os.Mkdir(outDirectory, 0o755); err != nil {
-		return nil, err
-	}
-
-	if err := o.saveCertificate(cert, outDirectory); err != nil {
-		return nil, err
-	}
-
-	return cert, nil
-}
-
-func (o *PeerOptions) createControlplane(caCert *bootstrap.Certificate) (*bootstrap.Certificate, error) {
-	cert, err := bootstrap.CreateControlplaneCertificate(caCert)
-	if err != nil {
-		return nil, err
-	}
-
-	outDirectory := config.ControlplaneDirectory(o.Name, o.Fabric, o.Path)
-	if err := os.Mkdir(outDirectory, 0o755); err != nil {
-		return nil, err
-	}
-
-	if err := o.saveCertificate(cert, outDirectory); err != nil {
-		return nil, err
-	}
-
-	return cert, nil
-}
-
-func (o *PeerOptions) createDataplane(caCert *bootstrap.Certificate) (*bootstrap.Certificate, error) {
-	cert, err := bootstrap.CreateDataplaneCertificate(caCert)
-	if err != nil {
-		return nil, err
-	}
-
-	outDirectory := config.DataplaneDirectory(o.Name, o.Fabric, o.Path)
 	if err := os.Mkdir(outDirectory, 0o755); err != nil {
 		return nil, err
 	}
@@ -147,19 +93,6 @@ func (o *PeerOptions) Run() error {
 	}
 
 	if _, err := o.createPeerCert(fabricCert); err != nil {
-		return err
-	}
-
-	caCert, err := o.createCA()
-	if err != nil {
-		return err
-	}
-
-	if _, err := o.createControlplane(caCert); err != nil {
-		return err
-	}
-
-	if _, err := o.createDataplane(caCert); err != nil {
 		return err
 	}
 

--- a/cmd/clusterlink/cmd/deploy/deploy_peer.go
+++ b/cmd/clusterlink/cmd/deploy/deploy_peer.go
@@ -41,11 +41,12 @@ import (
 
 const (
 	// StartAll deploys the clusterlink operator, converts the peer certificates to secrets,
-	// and deploys the operator ClusterLink custom resource to create the ClusterLink components.
+	// creates and deploys the operator ClusterLink custom resource to create the ClusterLink components.
 	StartAll = "all"
 	// StartOperator deploys only the operator and converts the peer certificates to secrets.
+	// Creates a custom resource example file that can be deployed to the operator.
 	StartOperator = "operator"
-	// NoStart doesn't deploy anything but creates custom resource YAMLs.
+	// NoStart doesn't deploy the operator and creates a "k8s.yaml" file that allow to deploy ClusterLink without the operator.
 	NoStart = "none"
 )
 
@@ -153,34 +154,29 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 	// Read certificates
-	fabricCert, err := bootstrap.ReadCertificates(
-		config.FabricDirectory(o.Fabric, o.Path), false)
+	fabricCert, err := bootstrap.ReadCertificates(config.FabricDirectory(o.Fabric, o.Path), false)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read fabric certificate: %w", err)
 	}
 
-	peerCert, err := bootstrap.ReadCertificates(
-		config.PeerDirectory(o.Name, o.Fabric, o.Path), true)
+	peerCert, err := bootstrap.ReadCertificates(config.PeerDirectory(o.Name, o.Fabric, o.Path), true)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read peer certificate: %w", err)
 	}
 
-	caCert, err := bootstrap.ReadCertificates(
-		config.CADirectory(o.Name, o.Fabric, o.Path), false)
+	caCert, err := bootstrap.CreateCACertificate()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create CA certificate: %w", err)
 	}
 
-	controlplaneCert, err := bootstrap.ReadCertificates(
-		config.ControlplaneDirectory(o.Name, o.Fabric, o.Path), true)
+	controlplaneCert, err := bootstrap.CreateControlplaneCertificate(caCert)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create controlplane certificates: %w", err)
 	}
 
-	dataplaneCert, err := bootstrap.ReadCertificates(
-		config.DataplaneDirectory(o.Name, o.Fabric, o.Path), true)
+	dataplaneCert, err := bootstrap.CreateDataplaneCertificate(caCert)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create dataplane certificates: %w", err)
 	}
 
 	// Create k8s deployment YAML
@@ -201,28 +197,18 @@ func (o *PeerOptions) Run() error {
 		Tag:                     o.Tag,
 	}
 
-	k8sConfig, err := platform.K8SConfig(platformCfg)
-	if err != nil {
-		return err
-	}
-
-	outPath := filepath.Join(peerDir, config.K8SYAMLFile)
-	if err := os.WriteFile(outPath, k8sConfig, 0o600); err != nil {
-		return err
-	}
-
-	// Create clusterlink instance YAML for the operator.
-	clConfig, err := platform.K8SClusterLinkInstanceConfig(platformCfg, "cl-instance")
-	if err != nil {
-		return err
-	}
-
-	clOutPath := filepath.Join(peerDir, config.K8SClusterLinkInstanceYAMLFile)
-	if err := os.WriteFile(clOutPath, clConfig, 0o600); err != nil {
-		return err
-	}
-
 	if o.StartInstance == NoStart {
+		// Create a YAML file for deployment without using the operator.
+		k8sConfig, err := platform.K8SConfig(platformCfg)
+		if err != nil {
+			return err
+		}
+
+		outPath := filepath.Join(peerDir, config.K8SYAMLFile)
+		if err := os.WriteFile(outPath, k8sConfig, 0o600); err != nil {
+			return fmt.Errorf("failed to write YAML file: %w", err)
+		}
+
 		return nil
 	}
 
@@ -253,6 +239,7 @@ func (o *PeerOptions) Run() error {
 	if err := o.deployDir("operator/rbac/*", resource); err != nil {
 		return err
 	}
+
 	if err := o.deployDir("crds/*", resource); err != nil {
 		return err
 	}
@@ -262,6 +249,7 @@ func (o *PeerOptions) Run() error {
 	if err != nil {
 		return err
 	}
+
 	err = decoder.DecodeEach(
 		context.Background(),
 		strings.NewReader(string(secretConfig)),
@@ -272,22 +260,29 @@ func (o *PeerOptions) Run() error {
 		return err
 	}
 
+	// Create clusterlink instance YAML for the operator.
+	if o.IngressPort != apis.DefaultExternalPort { // Set the port config only if it has changed.
+		platformCfg.IngressPort = o.IngressPort
+	}
+
+	instance, err := platform.K8SClusterLinkInstanceConfig(platformCfg, "cl-instance")
+	if err != nil {
+		return err
+	}
+
 	// Create ClusterLink instance
 	if o.StartInstance == StartAll {
-		if o.IngressPort != apis.DefaultExternalPort {
-			platformCfg.IngressPort = o.IngressPort
-		}
-
-		instance, err := platform.K8SClusterLinkInstanceConfig(platformCfg, "cl-instance")
-		if err != nil {
-			return err
-		}
-
 		err = decoder.DecodeEach(context.Background(), strings.NewReader(string(instance)), decoder.CreateHandler(resource))
 		if errors.IsAlreadyExists(err) {
 			fmt.Println("CRD instance for ClusterLink (\"cl-instance\") was already exist.")
 		} else if err != nil {
 			return err
+		}
+	} else {
+		// Store an example for clusterlink instance YAML.
+		clOutPath := filepath.Join(peerDir, config.K8SClusterLinkInstanceYAMLFile)
+		if err := os.WriteFile(clOutPath, instance, 0o600); err != nil {
+			return fmt.Errorf("failed to write YAML file: %w", err)
 		}
 	}
 

--- a/website/content/en/docs/main/tasks/operator.md
+++ b/website/content/en/docs/main/tasks/operator.md
@@ -116,7 +116,8 @@ The `deploy peer` {{< anchor commandline-flags >}} command has the following fla
         `all` (default) starts the clusterlink operator, converts the peer certificates to secrets,
         and deploys the operator ClusterLink custom resource to create the ClusterLink components.
         `operator` deploys only the `ClusterLink` operator and convert the peer certificates to secrets.
-        `none` doesn't deploy anything but creates the ClusterLink custom resource YAML.
+        Creates a custom resource example file that can be deployed to the operator.
+        `none` doesn't deploy the operator and creates a `k8s.yaml` file that allows deploying ClusterLink without the operator.
    - **path**: Represents the path where the peer and fabric certificates are stored,
         by default is the working current working directory.
 
@@ -165,6 +166,6 @@ To deploy the ClusterLink without using the CLI, follow the instructions below:
     ```
 
 [user guide]: {{< relref "../getting-started/users#setup" >}}
-[ClusterLink tutorials]: {{< relref "../tutorials/" >}} 
+[ClusterLink tutorials]: {{< relref "../tutorials/" >}}
 [here]: https://kind.sigs.k8s.io/docs/user/loadbalancer/
 [common use case]: #the-common-use-case


### PR DESCRIPTION
Create the ClusterLink components' certificates on the `deploy peer`  instead of in the `create peer-cert` command.