### PR TITLE
cmd/cl-controlplane: Support dynamic peer certificates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.3
 require (
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/envoyproxy/go-control-plane v0.12.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -35,7 +36,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/pkg/controlplane/authz/manager.go
+++ b/pkg/controlplane/authz/manager.go
@@ -385,7 +385,9 @@ func (m *Manager) getPeerName() string {
 	return m.peerName
 }
 
-func (m *Manager) SetPeerCertificates(peerTLS *tls.ParsedCertData) error {
+func (m *Manager) SetPeerCertificates(peerTLS *tls.ParsedCertData, _ *tls.RawCertData) error {
+	m.logger.Info("Setting peer certificates.")
+
 	dnsNames := peerTLS.DNSNames()
 	if len(dnsNames) == 0 {
 		return fmt.Errorf("expected peer certificate to contain at least one DNS name")

--- a/pkg/controlplane/control/peer.go
+++ b/pkg/controlplane/control/peer.go
@@ -312,7 +312,9 @@ func newPeerMonitor(pr *v1alpha1.Peer, manager *peerManager) *peerMonitor {
 	return monitor
 }
 
-func (m *peerManager) SetPeerCertificates(peerTLS *tls.ParsedCertData) {
+func (m *peerManager) SetPeerCertificates(peerTLS *tls.ParsedCertData, _ *tls.RawCertData) error {
+	m.logger.Info("Setting peer certificates.")
+
 	m.peerTLSLock.Lock()
 	defer m.peerTLSLock.Unlock()
 
@@ -324,6 +326,8 @@ func (m *peerManager) SetPeerCertificates(peerTLS *tls.ParsedCertData) {
 	for _, mon := range m.monitors {
 		mon.SetClientCertificates(peerTLS)
 	}
+
+	return nil
 }
 
 // newPeerManager returns a new empty peerManager.

--- a/pkg/controlplane/peer/certs.go
+++ b/pkg/controlplane/peer/certs.go
@@ -1,0 +1,166 @@
+// Copyright (c) The ClusterLink Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peer
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+
+	"github.com/clusterlink-net/clusterlink/pkg/util/tls"
+)
+
+// CertsConsumer represents a consumer of peer TLS certificates.
+type CertsConsumer interface {
+	SetPeerCertificates(parsedCertData *tls.ParsedCertData, rawCertData *tls.RawCertData) error
+}
+
+// parseError represents an error in parsing the peer certificates.
+type parseError struct {
+	err error
+}
+
+func (e parseError) Error() string {
+	return e.err.Error()
+}
+
+// CertsWatcher watches certificate updates.
+type CertsWatcher struct {
+	caPath   string
+	certPath string
+	keyPath  string
+
+	stopCh    chan struct{}
+	consumers []CertsConsumer
+
+	logger *logrus.Entry
+}
+
+// Name of the watcher.
+func (w *CertsWatcher) Name() string {
+	return "certs-watcher"
+}
+
+// AddConsumer adds a new peer certificates consumer.
+// This function is not thread-safe.
+func (w *CertsWatcher) AddConsumer(consumer CertsConsumer) {
+	w.consumers = append(w.consumers, consumer)
+}
+
+// ReadCertsAndUpdateConsumers reads the peer certificates and updates the consumers.
+func (w *CertsWatcher) ReadCertsAndUpdateConsumers() error {
+	w.logger.Infof("Updating certificates.")
+
+	parsedCertData, rawCertData, err := tls.ParseFiles(w.caPath, w.certPath, w.keyPath)
+	if err != nil {
+		return &parseError{err: err}
+	}
+
+	for _, consumer := range w.consumers {
+		if err := consumer.SetPeerCertificates(parsedCertData, rawCertData); err != nil {
+			return fmt.Errorf("error setting peer certificates on %v: %w", consumer, err)
+		}
+	}
+
+	return nil
+}
+
+// Start the certs watcher.
+func (w *CertsWatcher) Start() error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("cannot initialize file watcher: %w", err)
+	}
+
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			w.logger.Warnf("Cannot close watcher: %v", err)
+		}
+	}()
+
+	watchedFiles := []string{w.caPath, w.certPath, w.keyPath}
+	watchedDirs := make(map[string]interface{})
+	for _, file := range watchedFiles {
+		dir := path.Dir(file)
+		if _, ok := watchedDirs[dir]; !ok {
+			w.logger.Infof("Watching: %s.", dir)
+			if err := watcher.Add(dir); err != nil {
+				return fmt.Errorf("cannot watch directory '%s': %w", dir, err)
+			}
+			watchedDirs[dir] = nil
+		}
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	certsModified := false
+	for {
+		select {
+		case <-w.stopCh:
+			return nil
+		case event := <-watcher.Events:
+			w.logger.Debugf("Event: %v", event)
+			certsModified = true
+		case err := <-watcher.Errors:
+			w.logger.Errorf("Error: %v", err)
+			return err
+		case <-ticker.C:
+			if !certsModified {
+				continue
+			}
+
+			w.logger.Infof("Certificates modified.")
+			certsModified = false
+
+			if err = w.ReadCertsAndUpdateConsumers(); err == nil {
+				continue
+			}
+
+			w.logger.Infof("Error: %v", err)
+
+			if !errors.Is(err, &parseError{}) {
+				return err
+			}
+
+			w.logger.Errorf("Error parsing peer TLS certificates: %v.", err)
+		}
+	}
+}
+
+// Stop the watcher.
+func (w *CertsWatcher) Stop() error {
+	close(w.stopCh)
+	return nil
+}
+
+// GracefulStop does a graceful stop of the watcher.
+func (w *CertsWatcher) GracefulStop() error {
+	return w.Stop()
+}
+
+// NewWatcher returns a new certificate files watcher.
+func NewWatcher(caPath, certPath, keyPath string) *CertsWatcher {
+	return &CertsWatcher{
+		caPath:   caPath,
+		certPath: certPath,
+		keyPath:  keyPath,
+		stopCh:   make(chan struct{}),
+		logger:   logrus.WithField("component", "controlplane.peer.certs-watcher"),
+	}
+}

--- a/pkg/controlplane/xds/manager.go
+++ b/pkg/controlplane/xds/manager.go
@@ -212,7 +212,7 @@ func (m *Manager) DeleteImport(name types.NamespacedName) error {
 }
 
 // SetPeerCertificates sets the TLS certificates used for peer-to-peer communication.
-func (m *Manager) SetPeerCertificates(rawCertData *utiltls.RawCertData) error {
+func (m *Manager) SetPeerCertificates(_ *utiltls.ParsedCertData, rawCertData *utiltls.RawCertData) error {
 	m.logger.Info("Setting peer certificates.")
 
 	certificateSecret := &tls.Secret{

--- a/pkg/dataplane/client/xds.go
+++ b/pkg/dataplane/client/xds.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/sirupsen/logrus"
@@ -44,6 +45,7 @@ func (x *XDSClient) runFetcher(resourceType string) error {
 		fetcher, err := newFetcher(context.Background(), x.controlplaneClient, resourceType, x.dataplane)
 		if err != nil {
 			x.logger.Errorf("Failed to initialize %s fetcher: %v.", resourceType, err)
+			time.Sleep(time.Second)
 			continue
 		}
 		x.logger.Infof("Successfully initialized client for %s type.", resourceType)

--- a/pkg/util/runnable/manager.go
+++ b/pkg/util/runnable/manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Runnable represents a runnable instance.
+// Instance represents a runnable instance.
 type Instance interface {
 	Name() string
 	Start() error

--- a/tests/e2e/k8s/test_dynamic.go
+++ b/tests/e2e/k8s/test_dynamic.go
@@ -1,0 +1,97 @@
+// Copyright (c) The ClusterLink Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/clusterlink-net/clusterlink/cmd/clusterlink/config"
+	"github.com/clusterlink-net/clusterlink/pkg/apis/clusterlink.net/v1alpha1"
+	"github.com/clusterlink-net/clusterlink/pkg/bootstrap"
+	"github.com/clusterlink-net/clusterlink/tests/e2e/k8s/services"
+	"github.com/clusterlink-net/clusterlink/tests/e2e/k8s/services/httpecho"
+	"github.com/clusterlink-net/clusterlink/tests/e2e/k8s/util"
+)
+
+func (s *TestSuite) TestDynamicPeerCertificates() {
+	s.RunOnAllDataplaneTypes(func(cfg *util.PeerConfig) {
+		cl, err := s.fabric.DeployClusterlinks(2, cfg)
+		require.Nil(s.T(), err)
+
+		require.Nil(s.T(), cl[0].CreateService(&httpEchoService))
+		require.Nil(s.T(), cl[0].CreateExport(&httpEchoService))
+		require.Nil(s.T(), cl[0].CreatePolicy(util.PolicyAllowAll))
+		require.Nil(s.T(), cl[1].CreatePeer(cl[0]))
+
+		importedService := &util.Service{
+			Name: httpEchoService.Name,
+			Port: 80,
+		}
+		require.Nil(s.T(), cl[1].CreateImport(importedService, cl[0], httpEchoService.Name))
+
+		require.Nil(s.T(), cl[1].CreatePolicy(util.PolicyAllowAll))
+
+		_, err = cl[1].AccessService(httpecho.GetEchoValue, importedService, true, nil)
+		require.Nil(s.T(), err)
+
+		// create a new fabric certificate
+		fabricCert, err := bootstrap.CreateFabricCertificate(config.DefaultFabric)
+		require.Nil(s.T(), err)
+
+		// create new peer certificates
+		var peerCerts []*bootstrap.Certificate
+		for i := 0; i < 2; i++ {
+			peerCert, err := bootstrap.CreatePeerCertificate(cl[0].Name(), fabricCert)
+			require.Nil(s.T(), err)
+			peerCerts = append(peerCerts, peerCert)
+		}
+
+		// update peer certificates on cl[1]
+		require.Nil(s.T(), cl[1].UpdatePeerCertificates(fabricCert, peerCerts[0]))
+
+		// verify peer becomes unreachable
+		require.Nil(s.T(), cl[1].WaitForPeerCondition(
+			&v1alpha1.Peer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cl[0].Name(),
+					Namespace: cl[0].Namespace(),
+				},
+			},
+			v1alpha1.PeerReachable,
+			false))
+
+		// verify service is no longer accessible
+		_, err = cl[1].AccessService(httpecho.GetEchoValue, importedService, false, &services.ConnectionResetError{})
+		require.ErrorIs(s.T(), err, &services.ConnectionResetError{})
+
+		// update peer certificates on cl[0]
+		require.Nil(s.T(), cl[0].UpdatePeerCertificates(fabricCert, peerCerts[1]))
+
+		// verify peer becomes reachable
+		require.Nil(s.T(), cl[1].WaitForPeerCondition(
+			&v1alpha1.Peer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cl[0].Name(),
+					Namespace: cl[0].Namespace(),
+				},
+			},
+			v1alpha1.PeerReachable,
+			true))
+
+		// verify access is back
+		_, err = cl[1].AccessService(httpecho.GetEchoValue, importedService, false, nil)
+		require.Nil(s.T(), err)
+	})
+}


### PR DESCRIPTION
This PR changes the controlplane to watch the peer certificate files for changes, in order to support dynamic peer certificates.

Note that when switching TLS certificates, existing connections are still valid.
The client-side controlplane (the importer) terminates those controlplane connections when switching certificates.
However, if only the server switches certificates, the server will continue to allow authz connections, which will be dropped only at the tunnel establishment phase (where a new connection is used).