### PR TITLE
controlplane: Change listen port number

### DIFF
--- a/pkg/controlplane/api/servername.go
+++ b/pkg/controlplane/api/servername.go
@@ -15,5 +15,5 @@ package api
 
 const (
 	// ListenPort is the port used by the dataplane to access the controlplane.
-	ListenPort = 444
+	ListenPort = 4444
 )


### PR DESCRIPTION
Update the controlplane port to be higher than 1024 (below does not allow for non-root users in OpenShift clusters).