### PR TITLE
[website] enable and use git info for lastmod time

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -12,10 +12,13 @@ enableRobotsTXT = true
 disableAliases = true
 
 # Will give values to .Lastmod etc.
-enableGitInfo = false
+enableGitInfo = true
 
 # Comment out to enable taxonomies in Docsy
 # disableKinds = ["taxonomy", "taxonomyTerm"]
+
+[frontmatter]
+lastmod = ["lastmod", ":git", "date", "publishDate"]
 
 # You can add your own taxonomies
 [taxonomies]


### PR DESCRIPTION
Change config to enable last modification time in frontmatter based on available metadata.
The use of GitInfo is synchronized with netlify.toml setting (previously disabled on local builds and enabled on netlify only)