### PR TITLE
website: Fix allow-all-policy.md

### DIFF
--- a/website/content/en/docs/main/tutorials/iperf/index.md
+++ b/website/content/en/docs/main/tutorials/iperf/index.md
@@ -173,7 +173,43 @@ spec:
 
 ### Set-up access policies
 
+Create access policies on both clusters to allow connectivity:
+
+*Client cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
 {{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+*Server cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
+{{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+For more details regarding policy configuration, see [policies][] documentation.
 
 ## Test service connectivity
 
@@ -249,3 +285,4 @@ iperf Done.
 
 [kind]: https://kind.sigs.k8s.io/
 [kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[policies]: {{< relref "../../concepts/policies/_index.md" >}}

--- a/website/content/en/docs/main/tutorials/nginx/index.md
+++ b/website/content/en/docs/main/tutorials/nginx/index.md
@@ -173,7 +173,43 @@ spec:
 
 ### Set-up access policies
 
+Create access policies on both clusters to allow connectivity:
+
+*Client cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
 {{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+*Server cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
+{{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+For more details regarding policy configuration, see [policies][] documentation.
 
 ## Test service connectivity
 
@@ -229,3 +265,4 @@ kubectl logs jobs/curl-nginx-homepage
 
 [kind]: https://kind.sigs.k8s.io/
 [kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[policies]: {{< relref "../../concepts/policies/_index.md" >}}

--- a/website/content/en/docs/v0.3/tutorials/iperf/index.md
+++ b/website/content/en/docs/v0.3/tutorials/iperf/index.md
@@ -173,7 +173,43 @@ spec:
 
 ### Set-up access policies
 
+Create access policies on both clusters to allow connectivity:
+
+*Client cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
 {{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+*Server cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
+{{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+For more details regarding policy configuration, see [policies][] documentation.
 
 ## Test service connectivity
 
@@ -249,3 +285,4 @@ iperf Done.
 
 [kind]: https://kind.sigs.k8s.io/
 [kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[policies]: {{< relref "../../concepts/policies/_index.md" >}}

--- a/website/content/en/docs/v0.3/tutorials/nginx/index.md
+++ b/website/content/en/docs/v0.3/tutorials/nginx/index.md
@@ -173,7 +173,43 @@ spec:
 
 ### Set-up access policies
 
+Create access policies on both clusters to allow connectivity:
+
+*Client cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
 {{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+*Server cluster*:
+
+{{< tabpane text=true >}}
+{{% tab header="File" %}}
+
+```sh
+kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
+```
+
+{{% /tab %}}
+{{% tab header="Full CR" %}}
+
+{{% readfile file="/static/files/tutorials/allow-all-policy.md" %}}
+
+{{% /tab %}}
+{{< /tabpane >}}
+
+For more details regarding policy configuration, see [policies][] documentation.
 
 ## Test service connectivity
 
@@ -229,3 +265,4 @@ kubectl logs jobs/curl-nginx-homepage
 
 [kind]: https://kind.sigs.k8s.io/
 [kind installation guide]: https://kind.sigs.k8s.io/docs/user/quick-start
+[policies]: {{< relref "../../concepts/policies/_index.md" >}}

--- a/website/static/files/tutorials/allow-all-policy.md
+++ b/website/static/files/tutorials/allow-all-policy.md
@@ -1,18 +1,4 @@
 
-Create access policies on both clusters to allow connectivity:
-
-*Client cluster*:
-
-{{< tabpane text=true >}}
-{{% tab header="File" %}}
-
-```sh
-kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
-```
-
-{{% /tab %}}
-{{% tab header="Full CR" %}}
-
 ```sh
 echo "
 apiVersion: clusterlink.net/v1alpha1
@@ -28,39 +14,3 @@ spec:
     - workloadSelector: {}
 " | kubectl apply -f -
 ```
-
-{{% /tab %}}
-{{< /tabpane >}}
-
-*Server cluster*:
-
-{{< tabpane text=true >}}
-{{% tab header="File" %}}
-
-```sh
-kubectl apply -f $TEST_FILES/clusterlink/allow-policy.yaml
-```
-
-{{% /tab %}}
-{{% tab header="Full CR" %}}
-
-```sh
-echo "
-apiVersion: clusterlink.net/v1alpha1
-kind: AccessPolicy
-metadata:
-  name: allow-policy
-  namespace: default
-spec:
-  action: allow
-  from:
-    - workloadSelector: {}
-  to:
-    - workloadSelector: {}
-" | kubectl apply -f -
-```
-
-{{% /tab %}}
-{{< /tabpane >}}
-
-For more details regarding policy configuration, see [policies](../../concepts/policies) documentation.


### PR DESCRIPTION
`readfile` function is not able to support `tabpane` for more than one file, so I  remove the `tabpane` from the included file