### PR TITLE
golangci: Fix format warning

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,7 @@ linters:
     - bodyclose
     - contextcheck
     - durationcheck
-    - errcheck 
+    - errcheck
     - errname
     - errorlint
     - exportloopref
@@ -122,7 +122,8 @@ linters-settings:
 
 output:
   # prefer the simplest output: `line-number` without saving to file
-  format: line-number
+  formats:
+    - format: line-number
   print-issued-lines: false
   print-linter-name: true
   # allow multiple reports per line

--- a/pkg/controlplane/control/manager.go
+++ b/pkg/controlplane/control/manager.go
@@ -889,7 +889,6 @@ func generateJWKSecret() ([]byte, error) {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(rsaKey),
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode JWK key: %w", err)
 	}


### PR DESCRIPTION
Fix format warnings: 
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`