### PR TITLE
Instance CRD: Support empty registry

### DIFF
--- a/config/crds/clusterlink.net_instances.yaml
+++ b/config/crds/clusterlink.net_instances.yaml
@@ -41,7 +41,6 @@ spec:
             description: InstanceSpec defines the desired state of a ClusterLink instance.
             properties:
               containerRegistry:
-                default: ghcr.io/clusterlink-net
                 description: ContainerRegistry is the container registry to pull the
                   ClusterLink project images.
                 type: string

--- a/pkg/apis/clusterlink.net/v1alpha1/instance_types.go
+++ b/pkg/apis/clusterlink.net/v1alpha1/instance_types.go
@@ -117,7 +117,6 @@ type InstanceSpec struct {
 	// +kubebuilder:default=info
 	// LogLevel define the ClusterLink components log level.
 	LogLevel string `json:"logLevel,omitempty"`
-	// +kubebuilder:default="ghcr.io/clusterlink-net"
 	// ContainerRegistry is the container registry to pull the ClusterLink project images.
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
 	// +kubebuilder:default="latest"

--- a/pkg/operator/controller/instance_controller_test.go
+++ b/pkg/operator/controller/instance_controller_test.go
@@ -191,7 +191,7 @@ func TestClusterLinkController(t *testing.T) {
 		// Check controlplane fields
 		cp := &appsv1.Deployment{}
 		getResource(t, cpID, cp)
-		cpImage := "ghcr.io/clusterlink-net/" + cpapi.Name + ":latest"
+		cpImage := cpapi.Name + ":latest"
 		require.Equal(t, cpImage, cp.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, "info", cp.Spec.Template.Spec.Containers[0].Args[1])
 
@@ -203,7 +203,7 @@ func TestClusterLinkController(t *testing.T) {
 		// Check Dataplane fields
 		dp := &appsv1.Deployment{}
 		getResource(t, dpID, dp)
-		envoyImage := "ghcr.io/clusterlink-net/" + dpapi.Name + ":latest"
+		envoyImage := dpapi.Name + ":latest"
 		require.Equal(t, envoyImage, dp.Spec.Template.Spec.Containers[0].Image)
 		require.Equal(t, int32(1), *dp.Spec.Replicas)
 		require.Equal(t, "info", dp.Spec.Template.Spec.Containers[0].Args[1])


### PR DESCRIPTION
This PR changes the Instance CRD to support
an empty container registry (i.e. a local registry). The clusterlink CLI will still use the default gchr.io/clusterlink-net registry.