### PR TITLE
Cache TLS sessions

### DIFF
--- a/pkg/dataplane/server/dataplane.go
+++ b/pkg/dataplane/server/dataplane.go
@@ -237,8 +237,9 @@ func NewDataplane(
 		listeners:      make(map[string]*listener.Listener),
 		listenerEnd:    make(map[string]chan bool),
 		tlsConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ClientAuth: tls.RequireAndVerifyClientCert,
+			MinVersion:         tls.VersionTLS12,
+			ClientAuth:         tls.RequireAndVerifyClientCert,
+			ClientSessionCache: tls.NewLRUClientSessionCache(64),
 		},
 		logger: logger,
 	}

--- a/pkg/util/tls/util.go
+++ b/pkg/util/tls/util.go
@@ -102,10 +102,11 @@ func (c *ParsedCertData) ServerConfig() *tls.Config {
 // ClientConfig return a TLS configuration for a client.
 func (c *ParsedCertData) ClientConfig(sni string) *tls.Config {
 	return &tls.Config{
-		MinVersion:   tls.VersionTLS12,
-		Certificates: []tls.Certificate{c.certificate},
-		RootCAs:      c.ca,
-		ServerName:   sni,
+		MinVersion:         tls.VersionTLS12,
+		ClientSessionCache: tls.NewLRUClientSessionCache(64),
+		Certificates:       []tls.Certificate{c.certificate},
+		RootCAs:            c.ca,
+		ServerName:         sni,
 	}
 }
 


### PR DESCRIPTION
This PR adds a TLS session cache used by controlplane and go-dataplane TLS clients.