### PR TITLE
fix notify note to look as the rest of the notes

### DIFF
--- a/website/content/en/docs/main/tasks/relay/index.md
+++ b/website/content/en/docs/main/tasks/relay/index.md
@@ -56,8 +56,8 @@ This is an extension of the basic [nginx toturial][]. Please run it first and se
     ```
 
     {{< notice note >}}
-      The relay cluster certificates should use the same Fabric CA files as the server and the client.
-    {{< /notice >}}
+   The relay cluster certificates should use the same Fabric CA files as the server and the client.
+   {{< /notice >}}
 
 1. Deploy ClusterLink on the relay cluster:
 

--- a/website/content/en/docs/v0.4/tasks/relay/index.md
+++ b/website/content/en/docs/v0.4/tasks/relay/index.md
@@ -56,8 +56,8 @@ This is an extension of the basic [nginx toturial][]. Please run it first and se
     ```
 
     {{< notice note >}}
-      The relay cluster certificates should use the same Fabric CA files as the server and the client.
-    {{< /notice >}}
+   The relay cluster certificates should use the same Fabric CA files as the server and the client.
+   {{< /notice >}}
 
 1. Deploy ClusterLink on the relay cluster:
 


### PR DESCRIPTION
Fix notify note to have the correct background as all in website. both in main and v0.4

Currently note looks like the following:
<img width="768" alt="image" src="https://github.com/user-attachments/assets/4ac73649-50c7-4720-9fc6-9f8c2424570d">


Changed to looks like the following:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/8fac0e50-8cb2-4845-be34-b1efd071bbd1">
